### PR TITLE
Change/sender init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.4] - 2018-11-15
+#### Changed
+ * Modified Sender init class for kwargs arguments
+
 ## [1.1.3] - 2018-11-08
 #### Added
  * Sender class inherits from logging.handlers

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -22,6 +22,9 @@ class DevoSenderException(Exception):
     """ Default Devo Sender Exception """
     pass
 
+class Props:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
 
 class SenderConfigSSL:
     """
@@ -45,7 +48,8 @@ class SenderConfigSSL:
     """
 
     def __init__(self, address=None, port=None, key=None, debug=False,
-                 cert=None, chain=None, timeout=300, cert_reqs=True):
+                 cert=None, chain=None, timeout=300, cert_reqs=True,
+                 **kwargs):
         try:
             self.timeout = timeout * 1000
             self.address = (address, port)
@@ -78,7 +82,8 @@ class SenderConfigTCP:
 
     """
 
-    def __init__(self, address=None, port=None, debug=False, timeout=300):
+    def __init__(self, address=None, port=None, debug=False, timeout=300,
+                 **kwargs):
 
         try:
             self.timeout = timeout * 1000
@@ -106,14 +111,12 @@ class Sender(logging.Handler):
     """
     def __init__(self, config=None, **kwargs):
         if not config:
-            config = {
-                "address": kwargs.get('address'),
-                "port": kwargs.get('port'),
-                "key": kwargs.get('key'),
-                "cert": kwargs.get('cert'),
-                "chain": kwargs.get('chain'),
-                "cert_reqs": kwargs.get('cert_reqs')
-            }
+            config = SenderConfigTCP(**kwargs) if kwargs.get('type') is "TCP" \
+                else SenderConfigSSL(**kwargs) if kwargs.get('type') is "SSL" \
+                else None
+
+        if not config:
+            raise DevoSenderException("Problems with args passed to Sender")
 
         facility = kwargs.get('facility', FACILITY_USER)
         verbose_level = kwargs.get('verbose_level', "INFO")

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -96,7 +96,7 @@ class Sender(logging.Handler):
     """
     Class that manages the connection to the data collector
 
-    :param config: Config class
+    :param config: Config class, you can send params in kwargs
     :param verbose_level: Logger verbose level. Default level INFO
     :param sockettimeout: Socket timeout in minutes
     :param logger: logger. Default sys.console
@@ -104,9 +104,24 @@ class Sender(logging.Handler):
     >>>con = Sender(sender_config)
 
     """
+    def __init__(self, config=None, **kwargs):
+        if not config:
+            config = {
+                "address": kwargs.get('address'),
+                "port": kwargs.get('port'),
+                "key": kwargs.get('key'),
+                "cert": kwargs.get('cert'),
+                "chain": kwargs.get('chain'),
+                "cert_reqs": kwargs.get('cert_reqs')
+            }
 
-    def __init__(self, config, verbose_level='INFO', sockettimeout=5,
-                 logger=None, facility=FACILITY_USER, tag=None):
+        facility = kwargs.get('facility', FACILITY_USER)
+        verbose_level = kwargs.get('verbose_level', "INFO")
+        sockettimeout = kwargs.get('sockettimeout', 5)
+        logger = kwargs.get('logger', None)
+        tag = kwargs.get('tag', None)
+
+
         logging.Handler.__init__(self)
         if logger is None:
             self.logger = logging.getLogger('DevoSender')


### PR DESCRIPTION
Change of init method, now we can use **kwargs for accept all arguments direct without config object if its necessary