### PR TITLE
Fix Sender for logging and Date ints in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [3.0.2] - 2019-07-01
+#### Fixed
+ * API dates when int, verify if len its correct before add 3 zero
+ * Problem overriding tag when use Sender for logging
+
 ## [3.0.1] - 2019-06-27
 #### Fixed
  * Fixed always debug on reconnection

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![master Build Status](https://travis-ci.com/DevoInc/python-sdk.svg?branch=master)](https://travis-ci.com/DevoInc/python-sdk) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-sdk/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.0.1-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-sdk/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.0.2-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-sdk/)
 
 
 # Devo Python SDK

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/common/dates/dateparser.py
+++ b/devo/common/dates/dateparser.py
@@ -62,7 +62,9 @@ def default_from(date=None):
     :return: Millis for the API
     """
     if isinstance(date, int):
-        return date * 1000
+        if len(str(abs(date))) == 10:
+            return date * 1000
+        return date
     return parse(date, 'now()-day()')
 
 
@@ -73,5 +75,7 @@ def default_to(date=None):
     :return: Millis for the API
     """
     if isinstance(date, int):
-        return date * 1000
+        if len(str(abs(date))) == 10:
+            return date * 1000
+        return date
     return parse(date, 'now()')

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -441,7 +441,7 @@ class Sender(logging.Handler):
         elif isinstance(config, dict):
             con.logging['level'] = config.get("verbose_level", 10)
         else:
-            con.logging['tag'] = 10
+            con.logging['level'] = 10
 
         return con
 


### PR DESCRIPTION
## [3.0.2] - 2019-07-01
#### Fixed
 * API dates when int, verify if len its correct before add 3 zero
 * Problem overriding tag when use Sender for logging