### PR TITLE
Fix to allow the use of HTTP instead of HTTPS

### DIFF
--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -337,8 +337,9 @@ class Client:
         tries = 0
         while tries < self.retries:
             try:
-                response = requests.post("http://{}"
-                                         .format("/".join(self.address)),
+                protocol = "https" if self.config.ssl else "http"
+                response = requests.post("{}://{}"
+                                         .format(protocol, "/".join(self.address)),
                                          data=payload,
                                          headers=self._get_headers(payload),
                                          verify=false,

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -73,7 +73,7 @@ class ClientConfig:
         :param stream: Stream queries or not
         :param pragmas: pragmas por query: user, app_name and comment
         """
-        self.ssl = True
+        self.ssl = ssl 
         self.stream = stream
         self.response = response
         self.destination = destination
@@ -164,7 +164,7 @@ class Client:
 
         self.retries = retries
         self.timeout = timeout
-        self.verify = True
+        self.verify = config.ssl
 
     @staticmethod
     def _from_dict(config):
@@ -343,7 +343,7 @@ class Client:
                                          .format(protocol, "/".join(self.address)),
                                          data=payload,
                                          headers=self._get_headers(payload),
-                                         verify=False,
+                                         verify=self.verify,
                                          timeout=self.timeout,
                                          stream=self.config.stream)
                 if response.status_code != 200:

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -64,7 +64,7 @@ class ClientConfig:
     Main class for configuration of Client class. With diferent configurations
     """
     def __init__(self, processor=DEFAULT, response="json/simple/compact",
-                 destination=None, stream=True, pragmas=None,ssl=True):
+                 destination=None, stream=True, pragmas=None, ssl=True):
         """
         Initialize the API with this params, all optionals
         :param processor: processor for response, default is None
@@ -73,7 +73,7 @@ class ClientConfig:
         :param stream: Stream queries or not
         :param pragmas: pragmas por query: user, app_name and comment
         """
-        self.ssl = ssl 
+        self.ssl = ssl
         self.stream = stream
         self.response = response
         self.destination = destination
@@ -340,13 +340,13 @@ class Client:
         while tries < self.retries:
             try:
                 protocol = "https" if self.config.ssl else "http"
-                response = requests.post("{}://{}"
-                                         .format(protocol, "/".join(self.address)),
-                                         data=payload,
-                                         headers=self._get_headers(payload),
-                                         verify=self.verify,
-                                         timeout=self.timeout,
-                                         stream=self.config.stream)
+                response = requests.post(
+                    "{}://{}".format(protocol, "/".join(self.address)),
+                    data=payload,
+                    headers=self._get_headers(payload),
+                    verify=self.verify,
+                    timeout=self.timeout,
+                    stream=self.config.stream)
                 if response.status_code != 200:
                     raise DevoClientException(response)
 

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -343,7 +343,7 @@ class Client:
                                          .format(protocol, "/".join(self.address)),
                                          data=payload,
                                          headers=self._get_headers(payload),
-                                         verify=false,
+                                         verify=False,
                                          timeout=self.timeout,
                                          stream=self.config.stream)
                 if response.status_code != 200:

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -337,11 +337,11 @@ class Client:
         tries = 0
         while tries < self.retries:
             try:
-                response = requests.post("https://{}"
+                response = requests.post("http://{}"
                                          .format("/".join(self.address)),
                                          data=payload,
                                          headers=self._get_headers(payload),
-                                         verify=self.verify,
+                                         verify=false,
                                          timeout=self.timeout,
                                          stream=self.config.stream)
                 if response.status_code != 200:

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -73,7 +73,7 @@ class ClientConfig:
         :param stream: Stream queries or not
         :param pragmas: pragmas por query: user, app_name and comment
         """
-        self.ssl = true
+        self.ssl = True
         self.stream = stream
         self.response = response
         self.destination = destination

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -164,7 +164,7 @@ class Client:
 
         self.retries = retries
         self.timeout = timeout
-        self.verify = config.ssl
+        self.verify = self.config.ssl
 
     @staticmethod
     def _from_dict(config):
@@ -176,7 +176,8 @@ class Client:
                             response=config.get("response",
                                                 "json/simple/compact"),
                             destination=config.get("destination", None),
-                            stream=config.get("stream", True))
+                            stream=config.get("stream", True),
+                            ssl=config.get("ssl", True))
 
     def verify_certificates(self, option=True):
         """

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -64,7 +64,7 @@ class ClientConfig:
     Main class for configuration of Client class. With diferent configurations
     """
     def __init__(self, processor=DEFAULT, response="json/simple/compact",
-                 destination=None, stream=True, pragmas=None):
+                 destination=None, stream=True, pragmas=None,ssl=True):
         """
         Initialize the API with this params, all optionals
         :param processor: processor for response, default is None
@@ -73,6 +73,7 @@ class ClientConfig:
         :param stream: Stream queries or not
         :param pragmas: pragmas por query: user, app_name and comment
         """
+        self.ssl = true
         self.stream = stream
         self.response = response
         self.destination = destination

--- a/tests/api/query.py
+++ b/tests/api/query.py
@@ -18,11 +18,12 @@ class TestApi(unittest.TestCase):
         self.query_id = os.getenv('DEVO_API_QUERYID', None)
         self.user = os.getenv('DEVO_API_USER', "python-sdk-user")
         self.comment = os.getenv('DEVO_API_COMMENT', None)
-
+        self.ssl = os.getenv('DEVO_API_SSL_ENABLED', True)
+ 
     def test_from_dict(self):
         api = Client(config=
             {'key': self.key, 'secret': self.secret, 'address': self.uri,
-             'user': self.user, 'app_name': self.app_name}
+             'user': self.user, 'app_name': self.app_name, 'ssl': self.ssl}
             )
 
         self.assertTrue(isinstance(api, Client))

--- a/tests/api/query.py
+++ b/tests/api/query.py
@@ -19,7 +19,7 @@ class TestApi(unittest.TestCase):
         self.user = os.getenv('DEVO_API_USER', "python-sdk-user")
         self.comment = os.getenv('DEVO_API_COMMENT', None)
         self.ssl = os.getenv('DEVO_API_SSL_ENABLED', True)
- 
+
     def test_from_dict(self):
         api = Client(config=
             {'key': self.key, 'secret': self.secret, 'address': self.uri,


### PR DESCRIPTION
It looks like the client didn't support HTTP requests, I needed them to query a local serrea instance.

Some tests are failing, but it doesn't look related to these changes.