### PR TITLE
MR: [3.2.2] - 2020-03-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.2.2] - 2020-03-23
+#### Fixed
+ * wrongly assigned timeout from configuration
+
+#### Added
+ * "timeout" and "retries" parameters are able to be assigned from environment (DEVO_API_TIMEOUT, DEVO_API_RETRIES)
+
 ## [3.2.1] - 2020-03-17
 ### Changed
  * Changed version info in CLI for show only when asked

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -147,11 +147,11 @@ class Client:
                                                                      None)})
 
             retries = retries if retries else config.get("retries", 3)
-            timeout = timeout if retries else config.get("retries", 30)
+            timeout = timeout if timeout else config.get("timeout", 30)
             self.config = self._from_dict(config)
 
-        retries = retries if retries else 3
-        timeout = timeout if timeout else 30
+        retries = int(retries) if retries else 3
+        timeout = int(timeout) if timeout else 30
 
         self.auth = auth
         if not address:

--- a/devo/api/scripts/client_cli.py
+++ b/devo/api/scripts/client_cli.py
@@ -124,6 +124,8 @@ def configure(args):
             config.set("address", os.environ.get('DEVO_API_ADDRESS', None))
             config.set("user", os.environ.get('DEVO_API_USER', None))
             config.set("comment", os.environ.get('DEVO_API_COMMENT', None))
+            config.set("retries", os.environ.get('DEVO_API_RETRIES', None))
+            config.set("timeout", os.environ.get('DEVO_API_TIMEOUT', None))
 
         if args.get('default'):
             config.load_default_config(section="api")


### PR DESCRIPTION
## [3.2.2] - 2020-03-23
#### Fixed
 * wrongly assigned timeout from configuration

#### Added
 * "timeout" and "retries" parameters are able to be assigned from environment (DEVO_API_TIMEOUT, DEVO_API_RETRIES)
