### PR TITLE
[3.3.0] - 2020-04-14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
 - '3.5'
+- '3.6'
+- '3.7'
+- '3.8'
 install:
 - pip install .
 - pip install pyyaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * Testing in Travis for python 3.6, 3.7 and 3.8
  * Support in API to timeZone flag for Devo API
  * Support in API for new devo custom formats
- * Support for zip and buffer flags in Sender CLI
- * Functions to change buffer size of Sender
+ * Functions to change buffer size and compression_level of Sender
+ * Support for zip, buffer and compression_level flags in Sender CLI
+
  
 ### Changed
  * SSL Server support to adapt it from python 3.5 to python 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.2.4] - 2020-04-02
+## [3.2.5] - 2020-04-02
 ### Added
  * Added new security flags to Sender SSL Sender
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2020-04-14
+### Added
+ * Support for Python 3.8
+ * Testing in Travis for python 3.6, 3.7 and 3.8
+ * Support in API to timeZone flag for Devo API
+ * Support in API for new devo custom formats
+ * Support for zip and buffer flags in Sender CLI
+ * Functions to change buffer size of Sender
+ 
+### Changed
+ * SSL Server support to adapt it from python 3.5 to python 3.8
+ * SSL Send data tests 
+ * Requirements, updated.
+ 
+#### Removed
+ * unnecessary elifs in code following PEP8 recomendations
+ 
 ## [3.2.5] - 2020-04-02
 ### Added
  * Added new security flags to Sender SSL Sender

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * Testing in Travis for python 3.6, 3.7 and 3.8
  * Support in API to timeZone flag for Devo API
  * Support in API for new devo custom formats
+ * Documentation for new date formats
  * Functions to change buffer size and compression_level of Sender
  * Support for zip, buffer and compression_level flags in Sender CLI
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![master Build Status](https://travis-ci.com/DevoInc/python-sdk.svg?branch=master)](https://travis-ci.com/DevoInc/python-sdk) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-sdk/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.2.5-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-sdk/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.2.5-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
 
 
 # Devo Python SDK

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You can use sources files, clonning the project too:
 
 You has specific documentation in _[docs](docs)_ folder for each part of SDK:
 * [Sender](docs/sender/sender.md)
-* [Lookups](docs/sender/lookup.md)
+    * [Data](docs/sender/data.md)
+    * [Lookups](docs/sender/lookup.md)
 * [Common](docs/common.md)
 * API:
     * [Api query](docs/api/api.md)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![master Build Status](https://travis-ci.com/DevoInc/python-sdk.svg?branch=master)](https://travis-ci.com/DevoInc/python-sdk) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-sdk/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.2.5-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.0.0-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
 
 
 # Devo Python SDK

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![master Build Status](https://travis-ci.com/DevoInc/python-sdk.svg?branch=master)](https://travis-ci.com/DevoInc/python-sdk) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-sdk/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.2.4-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-sdk/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.2.5-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7-blue.svg)](https://pypi.org/project/devo-sdk/)
 
 
 # Devo Python SDK

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "3.2.5"
+__version__ = "3.3.0"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "3.2.4"
+__version__ = "3.2.5"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -387,13 +387,14 @@ class Client:
         """
         date_from = default_from(dates['from'])
         date_to = default_to(dates['to'])
-        payload = {"from": int(date_from / 1000)
-                           if isinstance(date_from, (int, float))
-                           else date_from,
-                   "to": int(date_to / 1000)
-                         if isinstance(date_to, (int, float))
-                         else date_to,
-                   "mode": {"type": opts['response']}}
+        payload = {
+            "from":
+                int(date_from / 1000) if isinstance(date_from, (int, float))
+                else date_from,
+            "to":
+                int(date_to / 1000) if isinstance(date_to, (int, float))
+                else date_to,
+            "mode": {"type": opts['response']}}
 
         if dates.get("timeZone"):
             payload['timeZone'] = dates.get("timeZone")

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -394,8 +394,9 @@ class Client:
                          if isinstance(date_to, (int, float))
                          else date_to,
                    "mode": {"type": opts['response']}}
+
         if dates.get("timeZone"):
-            payload['timeZone'] = dates.get("timezone")
+            payload['timeZone'] = dates.get("timeZone")
 
         if query:
             payload['query'] = query

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -40,16 +40,14 @@ def raise_exception(error):
     try:
         if isinstance(error, str):
             raise DevoClientException(proc_json()(error))
-        elif isinstance(error, DevoClientException):
+        if isinstance(error, DevoClientException):
             if isinstance(error.args[0], str):
                 raise DevoClientException(proc_json()(error.args[0]))
-            else:
-                raise DevoClientException(error.args[0])
-        elif isinstance(error, dict):
+            raise DevoClientException(error.args[0])
+        if isinstance(error, dict):
             raise DevoClientException(error)
-        else:
-            response_text = proc_json()(error.text)
-            raise DevoClientException(response_text)
+        response_text = proc_json()(error.text)
+        raise DevoClientException(response_text)
     except json.decoder.JSONDecodeError:
         raise DevoClientException(_format_error(error))
 
@@ -387,11 +385,18 @@ class Client:
         :param opts: destination -> Destination for the results
         :return: Return the formed payload
         """
-        payload = {"from": int(default_from(dates['from']) / 1000),
-                   "to": int(default_to(dates['to']) / 1000) if dates['to']
-                         is not None
-                         else None,
+        date_from = default_from(dates['from'])
+        date_to = default_to(dates['to'])
+        payload = {"from": int(date_from / 1000)
+                           if isinstance(date_from, (int, float))
+                           else date_from,
+                   "to": int(date_to / 1000)
+                         if isinstance(date_to, (int, float))
+                         else date_to,
                    "mode": {"type": opts['response']}}
+        if dates.get("timeZone"):
+            payload['timeZone'] = dates.get("timezone")
+
         if query:
             payload['query'] = query
 

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -218,7 +218,7 @@ class Client:
         :param dates: object with options for query, see doc
         :return: updated opts
         """
-        default = {'from': 'yesterday()', 'to': None}
+        default = {'from': '1h', 'to': None}
         if not dates:
             return default
 

--- a/devo/api/scripts/client_cli.py
+++ b/devo/api/scripts/client_cli.py
@@ -47,12 +47,13 @@ def cli(version):
                                'stdout')
 @click.option('--response', '-r', default="json/simple/compact",
               help='The output format. Default is json/simple/compact')
-@click.option('--from', default=None,
-              help='From date, and time for the query (YYYY-MM-DD hh:mm:ss). '
-                   'For valid formats see lt-common README')
-@click.option('--to', default=None,
-              help='To date, and time for the query (YYYY-MM-DD hh:mm:ss). '
-                   'For valid formats see lt-common README')
+@click.option('--from',
+              help='From date. For valid formats see API README.'
+                   ' Default if now - 1 hour')
+@click.option('--to',
+              help='To date. For valid formats see API README')
+@click.option('--timeZone',
+              help='Timezone info. For valid formats see API README')
 @click.option('--debug/--no-debug', help='For testing purposes', default=False)
 def query(**kwargs):
     """Perform query by query string"""
@@ -69,10 +70,16 @@ def query(**kwargs):
         if config['debug']:
             return
         exit()
-    reponse = api.query(query=config['query'],
-                        dates={"from": config['from'],
-                               "to": config['to'] if "to" in config.keys()
-                               else None})
+
+    dates = {}
+    if "to" in config.keys():
+        dates["from"] = config['from']
+    if "to" in config.keys():
+        dates["to"] = config['to']
+    if "timeZone" in config.keys():
+        dates['timeZone'] = config['timeZone']
+
+    reponse = api.query(query=config['query'], dates=dates)
 
     process_response(reponse, config)
 

--- a/devo/common/dates/dateparser.py
+++ b/devo/common/dates/dateparser.py
@@ -11,7 +11,7 @@ from .dateutils import test_date_format, to_millis, trunc_time
 from .dateoperations import parse_functions
 
 
-def parse(date_string=None, default='now()'):
+def parse(date_string=None, default='now'):
     """
     Parse a date string and return the result
     :param date_string: Date in string format
@@ -46,7 +46,13 @@ def parse_expression(date_string):
     """
     ops = parse_functions()
     try:
-        return eval(date_string, None, ops)
+        try:
+            result = eval(date_string, None, ops)
+        except:
+            return date_string
+        if isinstance(result, type(lambda x: 0)):
+            return date_string
+        return result
     except SyntaxError as err:
         sys.exit('ERROR: Syntax error on parse dates: ' + str(err))
     except TypeError as err:

--- a/devo/common/dates/dateparser.py
+++ b/devo/common/dates/dateparser.py
@@ -48,7 +48,7 @@ def parse_expression(date_string):
     try:
         try:
             result = eval(date_string, None, ops)
-        except:
+        except Exception:
             return date_string
         if isinstance(result, type(lambda x: 0)):
             return date_string

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -295,6 +295,30 @@ class Sender(logging.Handler):
         except Exception:
             return False
 
+    def compression_level(self, cl=-1):
+        """
+        Set compression level for zipped data
+
+        compression_level is an integer from 0 to 9 or -1
+        controlling the level of compression;
+        1 (Z_BEST_SPEED) is the fastest and produces the lower compression,
+        9 (Z_BEST_COMPRESSION) is the slowest and produces the highest
+        compression.
+        0 (Z_NO_COMPRESSION) has no compression.
+        The default value is -1 (Z_DEFAULT_COMPRESSION).
+
+        Z_DEFAULT_COMPRESSION represents a default compromise between
+        speed and compression (currently equivalent to level 6).
+        :param cl: (Compression_level). Default -1
+
+        :return True or False
+        """
+        try:
+            self.buffer.compression_level = cl
+            return True
+        except Exception:
+            return False
+
     def __status(self):
         """
         View Socket status, check if it's open

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -282,6 +282,19 @@ class Sender(logging.Handler):
         """
         self._sender_config.check_hostname = check_hostname
 
+    def buffer_size(self, size=19500):
+        """
+        Set buffer size for Sender:
+
+        :param size: New size of buffer. Default 19500
+        :return True or False
+        """
+        try:
+            self.buffer.length = size
+            return True
+        except Exception:
+            return False
+
     def __status(self):
         """
         View Socket status, check if it's open

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -202,7 +202,7 @@ class Sender(logging.Handler):
 
                     if self._sender_config.sec_level is not None:
                         self.logger.warning("Openssl's default security "
-                                            "level has been overwritten to"
+                                            "level has been overwritten to "
                                             "{}.".format(self.
                                                          _sender_config.
                                                          sec_level))
@@ -515,6 +515,9 @@ class Sender(logging.Handler):
             con.logging['level'] = config.get("verbose_level", 10)
         else:
             con.logging['level'] = logging.INFO
+
+        con.logger.setLevel(con.logging.get("level"))
+
 
         return con
 

--- a/devo/sender/scripts/sender_cli.py
+++ b/devo/sender/scripts/sender_cli.py
@@ -67,6 +67,9 @@ def cli(version):
 @click.option('--raw', is_flag=True, help='Send raw events from a '
                                           'file when using --file')
 @click.option('--debug/--no-debug', help='For testing purposes', default=False)
+@click.option('--zip/--no-zip', help='For testing purposes', default=False,
+              type=bool)
+@click.option('--buffer', help='Buffer size for zipped data.', type=int)
 @click.option('--env', '-e', help='Use env vars for configuration',
               default=False, type=bool)
 @click.option('--default', '-d', help='Use default file for configuration',

--- a/devo/sender/scripts/sender_cli.py
+++ b/devo/sender/scripts/sender_cli.py
@@ -70,6 +70,9 @@ def cli(version):
 @click.option('--zip/--no-zip', help='For testing purposes', default=False,
               type=bool)
 @click.option('--buffer', help='Buffer size for zipped data.', type=int)
+@click.option('--compression_level', help='Compression level for zipped data. '
+                                          'Read readme for more info',
+              type=int)
 @click.option('--env', '-e', help='Use env vars for configuration',
               default=False, type=bool)
 @click.option('--default', '-d', help='Use default file for configuration',
@@ -82,6 +85,8 @@ def data(**kwargs):
         con = Sender(config=config)
         if config.get("buffer", None) is not None:
             con.buffer_size(size=config.get("buffer"))
+        if config.get("compression_level", None) is not None:
+            con.compression_level(cl=config.get("compression_level"))
 
         if config['file']:
             if not os.path.isfile(config['file']):
@@ -167,6 +172,7 @@ def lookup(**kwargs):
     """Send csv lookups to devo"""
     config = configure_lookup(kwargs)
     con = Sender(config=config)
+
     lookup = Lookup(name=config['name'], historic_tag=None, con=con)
 
     # with open(config['file']) as file:

--- a/devo/sender/scripts/sender_cli.py
+++ b/devo/sender/scripts/sender_cli.py
@@ -80,6 +80,9 @@ def data(**kwargs):
     sended = 0
     try:
         con = Sender(config=config)
+        if config.get("buffer", None) is not None:
+            con.buffer_size(size=config.get("buffer"))
+
         if config['file']:
             if not os.path.isfile(config['file']):
                 print_error(str("File not exist"))
@@ -89,10 +92,12 @@ def data(**kwargs):
                     content = file.read()
                     if not config['raw']:
                         sended += con.send(tag=config['tag'], msg=content,
-                                           multiline=config['multiline'])
+                                           multiline=config['multiline'],
+                                           zip=config.get("zip", False))
                     else:
                         sended += con.send_raw(content,
-                                               multiline=config['multiline'])
+                                               multiline=config['multiline'],
+                                               zip=config.get("zip", False))
             else:
                 with open(config['file']) as file:
                     if config['header']:
@@ -101,9 +106,11 @@ def data(**kwargs):
                         if config['raw']:
                             sended += con.send_raw(line)
                         else:
-                            sended += con.send(tag=config['tag'], msg=line)
+                            sended += con.send(tag=config['tag'], msg=line,
+                                               zip=config.get("zip", False))
         else:
-            sended += con.send(tag=config['tag'], msg=config['line'])
+            sended += con.send(tag=config['tag'], msg=config['line'],
+                               zip=config.get("zip", False))
 
         con.close()
         if config.get("debug", False):

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -188,7 +188,7 @@ except Exception as error:
     print(error)
 ```
 
-####Flag list:
+#### Flag list:
 
 - DEFAULT: It is the default processor, it returns str or bytes, depending on the Python version
 - TO_STR: Return str, decoding data if receive bytes
@@ -213,28 +213,28 @@ api = Client(auth={"key":"myapikey", "secret":"myapisecret"},
 api.config.set_processor(processor)
 ```
 
-######- DEFAULT example in Python 3, response csv: 
+###### - DEFAULT example in Python 3, response csv: 
 ```python
 b'18/Jan/2019:09:58:51 +0000,/category.screen?category_id=BEDROOM&JSESSIONID=SD10SL6FF10ADFF7,404,http://www.bing.com/,Googlebot/2.1 ( http://www.googlebot.com/bot.html),gaqfse5dpcm690jdh5ho1f00o2:-'
 ```  
 
-######- DEFAULT example in Python 2.7, response csv: 
+###### - DEFAULT example in Python 2.7, response csv: 
 ```python
 '18/Jan/2019:09:58:51 +0000,/category.screen?category_id=BEDROOM&JSESSIONID=SD10SL6FF10ADFF7,404,http://www.bing.com/,Googlebot/2.1 ( http://www.googlebot.com/bot.html),gaqfse5dpcm690jdh5ho1f00o2:-'
 ```  
-######- TO_STR example in Python 3, response csv: 
+###### - TO_STR example in Python 3, response csv: 
 ```python
 '18/Jan/2019:09:58:51 +0000,/category.screen?category_id=BEDROOM&JSESSIONID=SD10SL6FF10ADFF7,404,http://www.bing.com/,Googlebot/2.1 ( http://www.googlebot.com/bot.html),gaqfse5dpcm690jdh5ho1f00o2:-'
 ```  
-######- TO_BYTES example in Python 2.7, response csv: 
+###### - TO_BYTES example in Python 2.7, response csv: 
 ```python
 b'18/Jan/2019:09:58:51 +0000,/category.screen?category_id=BEDROOM&JSESSIONID=SD10SL6FF10ADFF7,404,http://www.bing.com/,Googlebot/2.1 ( http://www.googlebot.com/bot.html),gaqfse5dpcm690jdh5ho1f00o2:-'
 ```  
-######- SIMPLECOMPACT_TO_ARRAY example in Python 3, response json/simple/compact: 
+###### - SIMPLECOMPACT_TO_ARRAY example in Python 3, response json/simple/compact: 
 ```python
 ['18/Jan/2019:09:58:51 +0000', '/category.screen?category_id=BEDROOM&JSESSIONID=SD10SL6FF10ADFF7', 404, 'http://www.bing.com/', 'Googlebot/2.1 ( http://www.googlebot.com/bot.html)', 'gaqfse5dpcm690jdh5ho1f00o2:-']
 ```  
-######- SIMPLECOMPACT_TO_OBJ example in Python 3, response json/simple/compact: 
+###### - SIMPLECOMPACT_TO_OBJ example in Python 3, response json/simple/compact: 
 ```python
 {'statusCode': 404, 'uri': '/category.screen?category_id=BEDROOM&JSESSIONID=SD10SL6FF10ADFF7', 'referralUri': 'http://www.bing.com/', 'userAgent': 'Googlebot/2.1 ( http://www.googlebot.com/bot.html)', 'cookie': 'gaqfse5dpcm690jdh5ho1f00o2:-', 'timestamp': '18/Jan/2019:09:58:51 +0000'}
 ```  
@@ -277,9 +277,9 @@ From                                                                          To
     `For all the examples that don't use a timestamp to specify a date, we assume that the moment of execution is 08-10-2018, 14:33:12 UTC.`
     This is a copy of official Devo docs you can see [HERE](https://docs.devo.com/confluence/ndt/api-reference/rest-api/running-queries-with-the-rest-api)
 
- ###____**_Dates_**
+ ### ____**_Dates_**
     
-|Operator|Description||
+|Operator|Example|Description|
 | ------------- | ------------- |---------|
 |today|	|Get the current day at 00:00:00. Note that the timeZone parameter affects the date settings.|
 | |  `"from": "today"` | This sets the starting date to 08-10-2018, 00:00:00 UTC
@@ -293,16 +293,46 @@ From                                                                          To
 | | | |
 |endday | | If you use this in the from field you will get the current day and the last second of the day. If you use it in the to field you will get the from date and the last second of that day. Note that the timeZone parameter affects the date settings.
 | |  `"from": "endday"` |  This sets the starting date to 08-10-2018, 23:59:59 UTC
-| |  `"from": 1515500531, "to": "endday"` |  This sets the ending date to 01-09-2018, 23:59:59 UTC.
+| |  `"from": 1515500531, "to": "endday"` |  (this timestamp corresponds to 01/09/2018 12:22:11 UTC) This sets the ending date to 01-09-2018, 23:59:59 UTC.
 | |  `"from": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 08-10-2018, 23:59:59 GMT+2 (08-10-2018, 21:59:59 UTC)
-| |  `"from": 1515493331,  "to": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
-| |  `"from": 1515452400, "to": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
+| |  `"from": 1515493331,  "to": "endday", "timeZone": "GMT+2"` | (this timestamp corresponds to 01/09/2018, 12:22:11 GMT+2) This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
+| |  `"from": 1515452400, "to": "endday", "timeZone": "GMT+2"` | (this timestamp corresponds to 01/09/2018, 01:00:00 GMT+2) This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
 | | | |
 |endmonth| | If you use this in the from field you will get the last day of the current month and the last second of that day. If you use it in the to field, you will get last day of the month indicated in the date field and the last second of that day. Note that the timeZone parameter affects the date settings.
 | |  `"from": "endmonth"` |  This sets the starting date to 31-10-2018, 23:59:59 UTC
 | |  `"to": "endmonth"` |  This sets the ending date to 30-09-2018, 23:59:59 UTC.
-| |  `"from": 1536150131, "to": "endmonth"` |  This sets the ending date to 30-09-2018, 23:59:59 UTC
-| |  `"from": 1536142931, "to": "endmonth", "timeZone": "GMT+2"` |  This sets the ending date to 30-09-2018 23:59:59 GMT+2 (30-09-2018, 21:59:59 UTC)
+| |  `"from": 1536150131, "to": "endmonth"` | (this timestamp corresponds to 05/09/2018, 12:22:11 UTC) This sets the ending date to 30-09-2018, 23:59:59 UTC
+| |  `"from": 1536142931, "to": "endmonth", "timeZone": "GMT+2"` | (this timestamp corresponds to 05/09/2018, 12:22:11 GMT+2) This sets the ending date to 30-09-2018 23:59:59 GMT+2 (30-09-2018, 21:59:59 UTC)
+ ### ____**_Days_**
+|Operator|Example|Description|
+| ------------- | ------------- |------------- |
+|d	| | Enter a number followed by d in the from parameter to substract N days from the current date. If you use it in the to field you will get the from date plus the indicated number of days.
+| |  `"from": "2d"` |  This sets the starting date to 06-10-2018, 14:33:12 UTC
+| |  `"from": 1536150131, "to": "2d"` |  This sets the ending date to 07-09-2018, 12:22:11 UTC
+| |  `"from": "5d",  "to": "2d"` | This sets the starting date to 03-10-2018, 14:33:12 UTC and the ending date to 05-10-2018, 14:33:12 UTC
+| | | |
+|ad| | Enter a number followed by ad in the from parameter to subtract N days from the current date and set time to 00:00:00. If you use it in the to field you will get the from date plus the indicated number of days and set time to 00:00:00. Note that the timeZone parameter affects the date settings.
+| |  `"from": "2ad"` |  This sets the starting date to 06-10-2018, 00:00:00 UTC
+| |  `"from": 1536150131, "to": "2ad"` |  (this timestamp corresponds to 05-09-2018, 12:22:11 UTC) This sets the ending date to 07-09-2018, 00:00:00 UTC
+| |  `"from":"5ad", "to": "2ad"` |  This sets the starting date to 03-10-2018, 00:00:00 UTC and the ending date to 05-10-2018, 00:00:00 UTC
+| |  `"from": "5ad", "to": "2ad"` | This sets the starting date to 03-10-2018, 00:00:00 UTC and the ending date to 05-10-2018, 00:00:00 UTC
+| |  `"from": 1536142931, "to": "2ad", "timeZone": "GMT+2"` |  (this timestamp corresponds to 05-09-2018, 12:22:11 UTC) This sets the ending date to 07-09-2018, 00:00:00 GMT+2 (06-09-2018, 22:00:00 UTC)
+| | `"from": "5ad", "to": "2ad", "timeZone": "GMT+2"` | This sets the starting date to 03-10-2018, 00:00:00 GMT+2 (02-10-2018, 22:00:00 UTC), and the ending date to 05-10-2018, 00:00:00 GMT+2 (04-10-2018, 22:00:00 UTC)
+
+ ### ____**_Hours_**
+|Operator|Example|Description|
+| ------------- | ------------- |------------- |
+|h| |Enter a number followed by h in the from parameter to subtract N hours from the current time. If you use it in the to field you will get the from time plus the indicated number of hours.
+| |  `"from": "2h"` | This sets the starting date to 08-10-2018, 12:33:12 UTC
+| |  `"from": "16h"` | This sets the starting date to 07-10-2018, 22:33:12 UTC
+| |  `"from": 1536150131, "to": "2h"` | (this timestamp corresponds to 05/09/2018, 12:22:11 UTC) This sets the ending date to 05-09-2018, 14:22:11 UTC
+| |  `"from": "5h", "to": "2h"` | This sets the starting date to 08-10-2018, 09:33:12 UTC and the ending date to 08-10-2018, 11:33:12 UTC
+|ah| | Enter a number followed by ah in the from parameter to subtract N hours from the current date at 00:00:00. If you use it in the to field you will add the indicated number of hours to the from date at 00:00:00. Note that the timeZone parameter affects the date settings.
+| |  `"from": "2ah"` | This sets the starting date to 07-10-2018, 22:00:00 UTC
+| |  `"from": "2ah", "timeZone": "GMT+2"` | This sets the starting date to 07-10-2018, 22:00:00 GMT+2 (07-10-2018, 20:00:00 UTC)
+| |  `"from": 1536114131, "to": "12ah"` | (this timestamp corresponds to 05-09-2018, 02:22:11 UTC) This sets the starting date to 07-10-2018, 22:00:00 GMT+2 (07-10-2018, 20:00:00 UTC)
+| |  `"from": 1536106931, "to": "12aH", "timeZone": "GMT+2"` | (this timestamp corresponds to 05-09-2018, 12:22:11 GMT+2) This sets the ending date to 05-09-2018, 12:00:00 GMT+2 (05-09-2018, 10:00:00 UTC)
+| |  `"from": "5ah", "to": "21ah"` | This sets the starting date to 07-10-2018, 19:00:00 UTC and the ending date to 07-10-2018, 21:00:00 UTC
 
 
 ## CLI USAGE

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -277,6 +277,33 @@ From                                                                          To
     `For all the examples that don't use a timestamp to specify a date, we assume that the moment of execution is 08-10-2018, 14:33:12 UTC.`
     This is a copy of official Devo docs you can see [HERE](https://docs.devo.com/confluence/ndt/api-reference/rest-api/running-queries-with-the-rest-api)
 
+ ###____**_Dates_**
+    
+|Operator|Description||
+| ------------- | ------------- |---------|
+|today|	|Get the current day at 00:00:00. Note that the timeZone parameter affects the date settings.|
+| |  `"from": "today"` | This sets the starting date to 08-10-2018, 00:00:00 UTC
+| |  `"to": "today"` | This sets the ending date to 08-10-2018, 00:00:00 UTC
+| |  `"from": "today", "timeZone": "GMT+2"` | This sets the starting date to 08-10-2018, 00:00:00 GMT+2 (07-10-2018, 22:00:00 UTC)
+| |  `"to": "today", "timeZone": "GMT+2"` | This sets the ending date to 08-10-2018, 00:00:00 GMT+2 (07-10-2018, 22:00:00 UTC)
+| | | |
+|now| | Get the current day and time
+| |  `"from": "now"` | This sets the starting date to 08-10-2018, 14:33:12 UTC
+| |  `"to": "now"` | This sets the ending date to 08-10-2018, 14:33:12 UTC
+| | | |
+|endday | | If you use this in the from field you will get the current day and the last second of the day. If you use it in the to field you will get the from date and the last second of that day. Note that the timeZone parameter affects the date settings.
+| |  `"from": "endday"` |  This sets the starting date to 08-10-2018, 23:59:59 UTC
+| |  `"from": 1515500531, "to": "endday"` |  This sets the ending date to 01-09-2018, 23:59:59 UTC.
+| |  `"from": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 08-10-2018, 23:59:59 GMT+2 (08-10-2018, 21:59:59 UTC)
+| |  `"from": 1515493331,  "to": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
+| |  `"from": 1515452400, "to": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
+| | | |
+|endmonth| | If you use this in the from field you will get the last day of the current month and the last second of that day. If you use it in the to field, you will get last day of the month indicated in the date field and the last second of that day. Note that the timeZone parameter affects the date settings.
+| |  `"from": "endmonth"` |  This sets the starting date to 31-10-2018, 23:59:59 UTC
+| |  `"to": "endmonth"` |  This sets the ending date to 30-09-2018, 23:59:59 UTC.
+| |  `"from": 1536150131, "to": "endmonth"` |  This sets the ending date to 30-09-2018, 23:59:59 UTC
+| |  `"from": 1536142931, "to": "endmonth", "timeZone": "GMT+2"` |  This sets the ending date to 30-09-2018 23:59:59 GMT+2 (30-09-2018, 21:59:59 UTC)
+
 
 ## CLI USAGE
 

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -78,7 +78,7 @@ api = Client(auth= {"key":"myapikey", "secret":"myapisecret"},
 `def query(self, **kwargs)`
 - query: Query to perform
 - query_id: Query ID to perform the query
-- dates: Dict with "from" and "to" keys
+- dates: Dict with "from" and "to" keys for date rangue, and "timeZone" for define timezone, if you want
 - limit: Max number of rows
 - offset: start of needle for query
 - comment: comment for query pragmas
@@ -116,7 +116,7 @@ print(response)
 api.config.response = "json/compact"
 
 response = api.query(query="from my.app.web.activityAll select * limit 10",
-                     dates= {'from': "2018-02-06 12:42:00"})
+                     dates= {'from': "2018-02-06 12:42:00", 'timeZone': "GMT+2"})
                      
 print(response)
 
@@ -179,7 +179,7 @@ api = Client(auth={"key":"myapikey", "secret":"myapisecret"},
              config=config)
              
 response = api.query(query="from my.app.web.activityAll select * limit 10",
-                     dates= {'from': "2018-02-06 12:42:00"})
+                     dates= {'from': "2018-02-06 12:42:00", 'timeZone': "GMT-2"})
 
 try:
     for item in response:
@@ -250,11 +250,13 @@ From                                                                          To
 ```
 
 ### Date Formats
-- Fixed format: As described on [Official Python Docs](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior). Accepted formats are:
+- **Fixed format:** As described on [Official Python Docs](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior). Accepted formats are:
     - '%Y-%m-%d %H:%M:%S'
     - '%Y-%m-%d', the time will be truncated to 00:00:00
-- Timestamp: From epoch in millis
-- Dynamic expression: Using the LinQ sintax we can use several functions
+    
+- **Timestamp:** From epoch in millis
+
+- **Dynamic expression:** Using the LinQ sintax we can use several functions. **timeZone can be wrong with this syntax**
     - Relative functions:
         - now(): Current date and time
         - today(): Current date and time fixed to 00:00:00
@@ -266,6 +268,14 @@ From                                                                          To
         - day(): Return 24 * 60 * 60
         - week(): Return 7 * 24 * 60 * 60
         - month(): Return 30 * 24 * 60 * 60
+        
+    With this sintax you can use expressions like: `from="now()-2*day()` equivalent to now minus two days.
+    Or `from=today()-6*month()`, etc.
+    
+- **New REST API dinamyc dates**: 
+
+    `For all the examples that don't use a timestamp to specify a date, we assume that the moment of execution is 08-10-2018, 14:33:12 UTC.`
+    This is a copy of official Devo docs you can see [HERE](https://docs.devo.com/confluence/ndt/api-reference/rest-api/running-queries-with-the-rest-api)
 
 
 ## CLI USAGE

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -282,57 +282,57 @@ From                                                                          To
 |Operator|Example|Description|
 | ------------- | ------------- |---------|
 |today|	|Get the current day at 00:00:00. Note that the timeZone parameter affects the date settings.|
-| |  `"from": "today"` | This sets the starting date to 08-10-2018, 00:00:00 UTC
-| |  `"to": "today"` | This sets the ending date to 08-10-2018, 00:00:00 UTC
-| |  `"from": "today", "timeZone": "GMT+2"` | This sets the starting date to 08-10-2018, 00:00:00 GMT+2 (07-10-2018, 22:00:00 UTC)
-| |  `"to": "today", "timeZone": "GMT+2"` | This sets the ending date to 08-10-2018, 00:00:00 GMT+2 (07-10-2018, 22:00:00 UTC)
+| |`"from": "today"`|This sets the starting date to 08-10-2018, 00:00:00 UTC
+| |`"to": "today"`|This sets the ending date to 08-10-2018, 00:00:00 UTC
+| |`"from": "today", "timeZone": "GMT+2"`|This sets the starting date to 08-10-2018, 00:00:00 GMT+2 (07-10-2018, 22:00:00 UTC)
+| |`"to": "today", "timeZone": "GMT+2"`|This sets the ending date to 08-10-2018, 00:00:00 GMT+2 (07-10-2018, 22:00:00 UTC)
 | | | |
-|now| | Get the current day and time
-| |  `"from": "now"` | This sets the starting date to 08-10-2018, 14:33:12 UTC
-| |  `"to": "now"` | This sets the ending date to 08-10-2018, 14:33:12 UTC
+|now| |Get the current day and time
+| |`"from": "now"`|This sets the starting date to 08-10-2018, 14:33:12 UTC
+| |`"to": "now"`|This sets the ending date to 08-10-2018, 14:33:12 UTC
 | | | |
-|endday | | If you use this in the from field you will get the current day and the last second of the day. If you use it in the to field you will get the from date and the last second of that day. Note that the timeZone parameter affects the date settings.
-| |  `"from": "endday"` |  This sets the starting date to 08-10-2018, 23:59:59 UTC
-| |  `"from": 1515500531, "to": "endday"` |  (this timestamp corresponds to 01/09/2018 12:22:11 UTC) This sets the ending date to 01-09-2018, 23:59:59 UTC.
-| |  `"from": "endday", "timeZone": "GMT+2"` |  This sets the ending date to 08-10-2018, 23:59:59 GMT+2 (08-10-2018, 21:59:59 UTC)
-| |  `"from": 1515493331,  "to": "endday", "timeZone": "GMT+2"` | (this timestamp corresponds to 01/09/2018, 12:22:11 GMT+2) This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
-| |  `"from": 1515452400, "to": "endday", "timeZone": "GMT+2"` | (this timestamp corresponds to 01/09/2018, 01:00:00 GMT+2) This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
+|endday | |If you use this in the from field you will get the current day and the last second of the day. If you use it in the to field you will get the from date and the last second of that day. Note that the timeZone parameter affects the date settings.
+| |`"from": "endday"`|This sets the starting date to 08-10-2018, 23:59:59 UTC
+| |`"from": 1515500531, "to": "endday"`|(this timestamp corresponds to 01/09/2018 12:22:11 UTC) This sets the ending date to 01-09-2018, 23:59:59 UTC.
+| |`"from": "endday", "timeZone": "GMT+2"`|This sets the ending date to 08-10-2018, 23:59:59 GMT+2 (08-10-2018, 21:59:59 UTC)
+| |`"from": 1515493331,  "to": "endday", "timeZone": "GMT+2"`|(this timestamp corresponds to 01/09/2018, 12:22:11 GMT+2) This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
+| |`"from": 1515452400, "to": "endday", "timeZone": "GMT+2"`|(this timestamp corresponds to 01/09/2018, 01:00:00 GMT+2) This sets the ending date to 01-09-2018 23:59:59 GMT+2 (01-09-2018, 21:59:59 UTC)
 | | | |
-|endmonth| | If you use this in the from field you will get the last day of the current month and the last second of that day. If you use it in the to field, you will get last day of the month indicated in the date field and the last second of that day. Note that the timeZone parameter affects the date settings.
-| |  `"from": "endmonth"` |  This sets the starting date to 31-10-2018, 23:59:59 UTC
-| |  `"to": "endmonth"` |  This sets the ending date to 30-09-2018, 23:59:59 UTC.
-| |  `"from": 1536150131, "to": "endmonth"` | (this timestamp corresponds to 05/09/2018, 12:22:11 UTC) This sets the ending date to 30-09-2018, 23:59:59 UTC
-| |  `"from": 1536142931, "to": "endmonth", "timeZone": "GMT+2"` | (this timestamp corresponds to 05/09/2018, 12:22:11 GMT+2) This sets the ending date to 30-09-2018 23:59:59 GMT+2 (30-09-2018, 21:59:59 UTC)
+|endmonth| |If you use this in the from field you will get the last day of the current month and the last second of that day. If you use it in the to field, you will get last day of the month indicated in the date field and the last second of that day. Note that the timeZone parameter affects the date settings.
+| |`"from": "endmonth"`|This sets the starting date to 31-10-2018, 23:59:59 UTC
+| |`"to": "endmonth"`|This sets the ending date to 30-09-2018, 23:59:59 UTC.
+| |`"from": 1536150131, "to": "endmonth"`|(this timestamp corresponds to 05/09/2018, 12:22:11 UTC) This sets the ending date to 30-09-2018, 23:59:59 UTC
+| |`"from": 1536142931, "to": "endmonth", "timeZone": "GMT+2"`|(this timestamp corresponds to 05/09/2018, 12:22:11 GMT+2) This sets the ending date to 30-09-2018 23:59:59 GMT+2 (30-09-2018, 21:59:59 UTC)
  ### ____**_Days_**
 |Operator|Example|Description|
 | ------------- | ------------- |------------- |
-|d	| | Enter a number followed by d in the from parameter to substract N days from the current date. If you use it in the to field you will get the from date plus the indicated number of days.
-| |  `"from": "2d"` |  This sets the starting date to 06-10-2018, 14:33:12 UTC
-| |  `"from": 1536150131, "to": "2d"` |  This sets the ending date to 07-09-2018, 12:22:11 UTC
-| |  `"from": "5d",  "to": "2d"` | This sets the starting date to 03-10-2018, 14:33:12 UTC and the ending date to 05-10-2018, 14:33:12 UTC
+|d	| |Enter a number followed by d in the from parameter to substract N days from the current date. If you use it in the to field you will get the from date plus the indicated number of days.
+| |`"from": "2d"`|This sets the starting date to 06-10-2018, 14:33:12 UTC
+| |`"from": 1536150131, "to": "2d"`|This sets the ending date to 07-09-2018, 12:22:11 UTC
+| |`"from": "5d",  "to": "2d"`|This sets the starting date to 03-10-2018, 14:33:12 UTC and the ending date to 05-10-2018, 14:33:12 UTC
 | | | |
-|ad| | Enter a number followed by ad in the from parameter to subtract N days from the current date and set time to 00:00:00. If you use it in the to field you will get the from date plus the indicated number of days and set time to 00:00:00. Note that the timeZone parameter affects the date settings.
-| |  `"from": "2ad"` |  This sets the starting date to 06-10-2018, 00:00:00 UTC
-| |  `"from": 1536150131, "to": "2ad"` |  (this timestamp corresponds to 05-09-2018, 12:22:11 UTC) This sets the ending date to 07-09-2018, 00:00:00 UTC
-| |  `"from":"5ad", "to": "2ad"` |  This sets the starting date to 03-10-2018, 00:00:00 UTC and the ending date to 05-10-2018, 00:00:00 UTC
-| |  `"from": "5ad", "to": "2ad"` | This sets the starting date to 03-10-2018, 00:00:00 UTC and the ending date to 05-10-2018, 00:00:00 UTC
-| |  `"from": 1536142931, "to": "2ad", "timeZone": "GMT+2"` |  (this timestamp corresponds to 05-09-2018, 12:22:11 UTC) This sets the ending date to 07-09-2018, 00:00:00 GMT+2 (06-09-2018, 22:00:00 UTC)
-| | `"from": "5ad", "to": "2ad", "timeZone": "GMT+2"` | This sets the starting date to 03-10-2018, 00:00:00 GMT+2 (02-10-2018, 22:00:00 UTC), and the ending date to 05-10-2018, 00:00:00 GMT+2 (04-10-2018, 22:00:00 UTC)
+|ad| |Enter a number followed by ad in the from parameter to subtract N days from the current date and set time to 00:00:00. If you use it in the to field you will get the from date plus the indicated number of days and set time to 00:00:00. Note that the timeZone parameter affects the date settings.
+| |`"from": "2ad"`|This sets the starting date to 06-10-2018, 00:00:00 UTC
+| |`"from": 1536150131, "to": "2ad"`|(this timestamp corresponds to 05-09-2018, 12:22:11 UTC) This sets the ending date to 07-09-2018, 00:00:00 UTC
+| |`"from":"5ad", "to": "2ad"`|This sets the starting date to 03-10-2018, 00:00:00 UTC and the ending date to 05-10-2018, 00:00:00 UTC
+| |`"from": "5ad", "to": "2ad"`|This sets the starting date to 03-10-2018, 00:00:00 UTC and the ending date to 05-10-2018, 00:00:00 UTC
+| |`"from": 1536142931, "to": "2ad", "timeZone": "GMT+2"`|(this timestamp corresponds to 05-09-2018, 12:22:11 UTC) This sets the ending date to 07-09-2018, 00:00:00 GMT+2 (06-09-2018, 22:00:00 UTC)
+| |`"from": "5ad", "to": "2ad", "timeZone": "GMT+2"`|This sets the starting date to 03-10-2018, 00:00:00 GMT+2 (02-10-2018, 22:00:00 UTC), and the ending date to 05-10-2018, 00:00:00 GMT+2 (04-10-2018, 22:00:00 UTC)
 
  ### ____**_Hours_**
 |Operator|Example|Description|
 | ------------- | ------------- |------------- |
 |h| |Enter a number followed by h in the from parameter to subtract N hours from the current time. If you use it in the to field you will get the from time plus the indicated number of hours.
-| |  `"from": "2h"` | This sets the starting date to 08-10-2018, 12:33:12 UTC
-| |  `"from": "16h"` | This sets the starting date to 07-10-2018, 22:33:12 UTC
-| |  `"from": 1536150131, "to": "2h"` | (this timestamp corresponds to 05/09/2018, 12:22:11 UTC) This sets the ending date to 05-09-2018, 14:22:11 UTC
-| |  `"from": "5h", "to": "2h"` | This sets the starting date to 08-10-2018, 09:33:12 UTC and the ending date to 08-10-2018, 11:33:12 UTC
-|ah| | Enter a number followed by ah in the from parameter to subtract N hours from the current date at 00:00:00. If you use it in the to field you will add the indicated number of hours to the from date at 00:00:00. Note that the timeZone parameter affects the date settings.
-| |  `"from": "2ah"` | This sets the starting date to 07-10-2018, 22:00:00 UTC
-| |  `"from": "2ah", "timeZone": "GMT+2"` | This sets the starting date to 07-10-2018, 22:00:00 GMT+2 (07-10-2018, 20:00:00 UTC)
-| |  `"from": 1536114131, "to": "12ah"` | (this timestamp corresponds to 05-09-2018, 02:22:11 UTC) This sets the starting date to 07-10-2018, 22:00:00 GMT+2 (07-10-2018, 20:00:00 UTC)
-| |  `"from": 1536106931, "to": "12aH", "timeZone": "GMT+2"` | (this timestamp corresponds to 05-09-2018, 12:22:11 GMT+2) This sets the ending date to 05-09-2018, 12:00:00 GMT+2 (05-09-2018, 10:00:00 UTC)
-| |  `"from": "5ah", "to": "21ah"` | This sets the starting date to 07-10-2018, 19:00:00 UTC and the ending date to 07-10-2018, 21:00:00 UTC
+| |`"from": "2h"`|This sets the starting date to 08-10-2018, 12:33:12 UTC
+| |`"from": "16h"`|This sets the starting date to 07-10-2018, 22:33:12 UTC
+| |`"from": 1536150131, "to": "2h"`|(this timestamp corresponds to 05/09/2018, 12:22:11 UTC) This sets the ending date to 05-09-2018, 14:22:11 UTC
+| |`"from": "5h", "to": "2h"`|This sets the starting date to 08-10-2018, 09:33:12 UTC and the ending date to 08-10-2018, 11:33:12 UTC
+|ah| |Enter a number followed by ah in the from parameter to subtract N hours from the current date at 00:00:00. If you use it in the to field you will add the indicated number of hours to the from date at 00:00:00. Note that the timeZone parameter affects the date settings.
+| |`"from": "2ah"`|This sets the starting date to 07-10-2018, 22:00:00 UTC
+| |`"from": "2ah", "timeZone": "GMT+2"`|This sets the starting date to 07-10-2018, 22:00:00 GMT+2 (07-10-2018, 20:00:00 UTC)
+| |`"from": 1536114131, "to": "12ah"`|(this timestamp corresponds to 05-09-2018, 02:22:11 UTC) This sets the starting date to 07-10-2018, 22:00:00 GMT+2 (07-10-2018, 20:00:00 UTC)
+| |`"from": 1536106931, "to": "12aH", "timeZone": "GMT+2"`|(this timestamp corresponds to 05-09-2018, 12:22:11 GMT+2) This sets the ending date to 05-09-2018, 12:00:00 GMT+2 (05-09-2018, 10:00:00 UTC)
+| |`"from": "5ah", "to": "21ah"`|This sets the starting date to 07-10-2018, 19:00:00 UTC and the ending date to 07-10-2018, 21:00:00 UTC
 
 
 ## CLI USAGE

--- a/docs/sender/data.md
+++ b/docs/sender/data.md
@@ -173,10 +173,17 @@ You can change the default compression level with:
 con.compression_level(cl=6)
 ```
 
-compression_level is an integer from 0 to 9 or -1 controlling the level of compression; 1 (Z_BEST_SPEED) 
-is the fastest and produces the lower compression, 9 (Z_BEST_COMPRESSION) is the slowest and produces the 
-highest compression. 0 (Z_NO_COMPRESSION) has no compression. The default value is -1 (Z_DEFAULT_COMPRESSION). 
-Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression (currently equivalent to level 6).
+compression_level is an integer from 0 to 9 or -1 controlling the level of compression. 
+
+* 1 (Z_BEST_SPEED) is the fastest and produces the lower compression.
+
+* 9 (Z_BEST_COMPRESSION) is the slowest and produces the 
+highest compression. 
+
+* 0 (Z_NO_COMPRESSION) has no compression. 
+
+* The default value is -1 (Z_DEFAULT_COMPRESSION). 
+  * Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression (currently equivalent to level 6).
 
 
 ### Extra info when send: 

--- a/docs/sender/data.md
+++ b/docs/sender/data.md
@@ -164,16 +164,19 @@ The compressed delivery will store the messages in a buffer that, when it is fil
 The default buffer length its _19500_ and you can change it with:
 
 ```python
-con.max_zip_buffer = 19500
+con.buffer_size(size=19500)
 ```
 
 You can change the default compression level with:
 
 ```python
-con.compression_level = 6
+con.compression_level(cl=6)
 ```
 
-compression_level is an integer from 0 to 9 or -1 controlling the level of compression; 1 (Z_BEST_SPEED) is the fastest and produces the lower compression, 9 (Z_BEST_COMPRESSION) is the slowest and produces the highest compression. 0 (Z_NO_COMPRESSION) has no compression. The default value is -1 (Z_DEFAULT_COMPRESSION). Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression (currently equivalent to level 6).
+compression_level is an integer from 0 to 9 or -1 controlling the level of compression; 1 (Z_BEST_SPEED) 
+is the fastest and produces the lower compression, 9 (Z_BEST_COMPRESSION) is the slowest and produces the 
+highest compression. 0 (Z_NO_COMPRESSION) has no compression. The default value is -1 (Z_DEFAULT_COMPRESSION). 
+Z_DEFAULT_COMPRESSION represents a default compromise between speed and compression (currently equivalent to level 6).
 
 
 ### Extra info when send: 

--- a/docs/sender/sender.md
+++ b/docs/sender/sender.md
@@ -1,4 +1,4 @@
-# devo-sender data
+# devo-sender
 ## Overview
 
 This library allows you to send logs to the Devo platform.
@@ -8,6 +8,10 @@ This library allows you to send logs to the Devo platform.
 - Allows to send real time data
 - Logger integration and logging handler capacity for Sender
 - Send lookups to Devo
+
+You have info about usage in scripts here:
+- [Data](docs/sender/data.md)
+- [Lookups](docs/sender/lookup.md)
 
 ## Endpoints
 ##### Sender
@@ -33,7 +37,7 @@ You have a special README to quickly show the important changes suffered from ve
 
 [You can go read it here](sender_v2_to_v3_major_changes.md)
 
-
+## CLI usages
 ####devo-sender data
 This command is used to send logs to Devo
 

--- a/docs/sender/sender.md
+++ b/docs/sender/sender.md
@@ -45,6 +45,7 @@ Usage: devo-sender data [OPTIONS]
 Options:
   -c, --config PATH             Optional JSON/Yaml File with configuration
                                 info.
+
   -a, --address TEXT            Devo relay address
   -p, --port TEXT               Devo relay address port
   --key TEXT                    Devo user key cert file.
@@ -54,24 +55,34 @@ Options:
   --verify_mode INTEGER         Verify mode for SSL Socket. Default: SSL
                                 default.You need use int "0" (CERT_NONE), "1"
                                 (CERT_OPTIONAL) or "2" (CERT_REQUIRED)
+
   --check_hostname BOOLEAN      Verify cert hostname. Default: True
   --multiline / --no-multiline  Flag for multiline (With break-line in msg).
                                 Default False
+
   --type TEXT                   Connection type: SSL or TCP
   -t, --tag TEXT                Tag / Table to which the data will be sent in
                                 Devo.
+
   -l, --line TEXT               For shipments of only one line, the text you
                                 want to send.
+
   -f, --file TEXT               The file that you want to send to Devo, which
                                 will be sent line by line.
+
   -h, --header BOOLEAN          This option is used to indicate if the file
                                 has headers or not, not to send them.
+
   --raw                         Send raw events from a file when using --file
   --debug / --no-debug          For testing purposes
+  --zip / --no-zip              For testing purposes
+  --buffer INTEGER              Buffer size for zipped data.
+  --compression_level INTEGER   Compression level for zipped data. Read readme
+                                for more info
+
   -e, --env BOOLEAN             Use env vars for configuration
   -d, --default BOOLEAN         Use default file for configuration
   --help                        Show this message and exit.
-
 ```
 
 Examples
@@ -106,6 +117,7 @@ Usage: devo-sender lookup [OPTIONS]
 Options:
   -c, --config PATH               Optional JSON/Yaml File with configuration
                                   info.
+
   -e, --env BOOLEAN               Use env vars for configuration
   -d, --default BOOLEAN           Use default file for configuration
   -a, --url, --address TEXT       Devo relay address
@@ -117,19 +129,23 @@ Options:
   --verify_mode INTEGER           Verify mode for SSL Socket. Default: SSL
                                   default.You need use int "0" (CERT_NONE),
                                   "1" (CERT_OPTIONAL) or "2" (CERT_REQUIRED)
+
   --check_hostname BOOLEAN        Verify cert hostname. Default: True
   --type TEXT                     Connection type: SSL or TCP
   -n, --name TEXT                 Name for Lookup.
   -ac, --action TEXT              INC or FULL.
   -f, --file TEXT                 The file that you want to send to Devo,
                                   which will be sent line by line.
+
   -lk, --lkey TEXT                Name of the column that contains the Lookup
                                   key. It has to be the exact name that
                                   appears in the header.
+
   -dk, --dkey TEXT                Name of the column that contains the
                                   action/delete key with "add" or "delete".It
                                   has to be the exact name that appears in the
                                   header.
+
   -dt, --detect-types / -ndt, --no-detect-types
                                   Detect types of fields. Default: False
   -d, --delimiter TEXT            CSV Delimiter char.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Click==7.0
-pyyaml==5.3.1
-requests===2.21.0
+click==7.1.1
+PyYAML==5.3.1
+requests==2.23.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-INSTALL_REQUIRES = ['requests>=2.21,<3', 'click>=7', 'pyyaml>=5.1']
+INSTALL_REQUIRES = ['requests==2.23.0', 'click==7.1.1', 'PyYAML==5.3.1']
 CLI = ['devo-sender=devo.sender.scripts.sender_cli:cli',
        'devo-api=devo.api.scripts.client_cli:cli']
 

--- a/tests/sender/cli.py
+++ b/tests/sender/cli.py
@@ -38,7 +38,7 @@ class TestSender(unittest.TestCase):
         configuration = Configuration()
         configuration.set("sender", {
             "key": self.key, "cert": self.cert, "chain": self.chain,
-            "address": self.address, "port": self.port, "sec_level": 0,
+            "address": self.address, "port": self.port,
             "verify_mode": 0, "check_hostname": False
         })
 
@@ -68,7 +68,6 @@ class TestSender(unittest.TestCase):
                                        "--key", self.local_key,
                                        "--cert", self.cert,
                                        "--chain", self.chain,
-                                      "--sec_level", 0,
                                       "--verify_mode", 0,
                                       '--check_hostname', False])
         self.assertIsInstance(result.exception, DevoSenderException)
@@ -84,7 +83,6 @@ class TestSender(unittest.TestCase):
                                       "--cert", self.cert,
                                       "--chain", self.chain,
                                       "--tag", self.my_app,
-                                      "--sec_level", 0,
                                       "--verify_mode", 0,
                                       '--check_hostname', False,
                                       "--line", "Test line"])

--- a/tests/sender/cli.py
+++ b/tests/sender/cli.py
@@ -13,9 +13,9 @@ except ImportError:
 
 class TestSender(unittest.TestCase):
     def setUp(self):
-        self.address = os.getenv('DEVO_SENDER_SERVER', "0.0.0.0")
+        self.address = os.getenv('DEVO_SENDER_SERVER', "127.0.0.1")
         self.port = int(os.getenv('DEVO_SENDER_PORT', 4488))
-        self.tcp_address = os.getenv('DEVO_SENDER_TCP_SERVER', "0.0.0.0")
+        self.tcp_address = os.getenv('DEVO_SENDER_TCP_SERVER', "127.0.0.1")
         self.tcp_port = int(os.getenv('DEVO_SENDER_TCP_PORT', 4489))
 
         self.key = os.getenv('DEVO_SENDER_KEY', CLIENT_KEY)
@@ -38,7 +38,8 @@ class TestSender(unittest.TestCase):
         configuration = Configuration()
         configuration.set("sender", {
             "key": self.key, "cert": self.cert, "chain": self.chain,
-            "address": self.address, "port": self.port,
+            "address": self.address, "port": self.port, "sec_level": 0,
+            "verify_mode": 0, "check_hostname": False
         })
 
         self.config_path = "/tmp/devo_sender_tests_config.json"
@@ -66,7 +67,10 @@ class TestSender(unittest.TestCase):
                                        "--port", "443",
                                        "--key", self.local_key,
                                        "--cert", self.cert,
-                                       "--chain", self.chain])
+                                       "--chain", self.chain,
+                                      "--sec_level", 0,
+                                      "--verify_mode", 0,
+                                      '--check_hostname', False])
         self.assertIsInstance(result.exception, DevoSenderException)
         self.assertIn("SSL conn establishment socket error",
                       result.exception.args[0])
@@ -80,6 +84,9 @@ class TestSender(unittest.TestCase):
                                       "--cert", self.cert,
                                       "--chain", self.chain,
                                       "--tag", self.my_app,
+                                      "--sec_level", 0,
+                                      "--verify_mode", 0,
+                                      '--check_hostname', False,
                                       "--line", "Test line"])
 
         self.assertIsNone(result.exception)

--- a/tests/sender/local_servers.py
+++ b/tests/sender/local_servers.py
@@ -1,28 +1,37 @@
 import threading
-import os
 import socket
+import asyncio
+import multiprocessing
+import os
 import ssl
 
 
 class SSLServer:
-    def __init__(self, ip="0.0.0.0", port=4488):
+    ip = "127.0.0.1"
+    port = 4488
+
+    def __init__(self):
         self.shutdown = False
-        self.server = None
         self.file_path = "".join((os.path.dirname(os.path.abspath(__file__)),
                                   os.sep))
-        self.server = threading.Thread(target=self.start_server,
-                                       kwargs={'ip': ip, 'port': port})
-        self.server.setDaemon(True)
-        self.server.start()
+        self.loop = asyncio.get_event_loop()
+        self.server_process = multiprocessing.Process(target=self.server,
+                                                 name='sslserver')
+        self.server_process.start()
 
-    '''
-    Implement the SSL SERVER
-    '''
-    def start_server(self, ip, port):
-        ssl_socket = socket.socket()
-        ssl_socket.bind((ip, port))
-        ssl_socket.listen(10)
-        stream = None
+    def server(self):
+        @asyncio.coroutine
+        def handle_connection(reader, writer):
+            addr = writer.get_extra_info('peername')
+            try:
+                while True:
+                    data = yield from reader.read(500)
+                    print("Server received {!r} from {}".format(data, addr))
+                    assert len(data) > 0, repr(data)
+                    writer.write(data)
+                    yield from writer.drain()
+            except:
+                writer.close()
 
         server_cert = os.getenv('DEVO_SENDER_SERVER_CRT',
                                 "{!s}local_certs/keys/server/server_cert.pem"
@@ -32,41 +41,26 @@ class SSLServer:
                                "{!s}local_certs/keys/server/"
                                "private/server_key.pem"
                                .format(self.file_path))
-        try:
-            while not self.shutdown:
-                conn, addr = ssl_socket.accept()
-                stream = ssl.wrap_socket(conn, server_side=True,
-                                         certfile=server_cert,
-                                         keyfile=server_key)
-                stream.settimeout(15)
-                self.connect_client(stream)
-        finally:
-            if stream:
-                stream.close()
 
-    '''
-    Read stream
-    '''
-    def connect_client(self, stream):
-        try:
-            while not self.shutdown:
-                data = stream.recv(8000)
-                stream.send(data)
-        except socket.timeout:
-            print("Timeout")
-        except ssl.SSLEOFError:
-            print("Socket closed by client when recv")
-        except Exception as error:
-            print("Other exception")
-            print(type(error))
-            print(error)
+        sc = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        sc.load_cert_chain(server_cert, server_key)
+
+        coro = asyncio.start_server(handle_connection, self.ip, self.port,
+                                    ssl=sc, loop=self.loop)
+        server = self.loop.run_until_complete(coro)
+
+        print('Serving on {}'.format(server.sockets[0].getsockname()))
+        self.loop.run_forever()
 
     def close_server(self):
         self.shutdown = True
+        self.loop.stop()
+        self.server_process.terminate()
+        self.server_process.join()
 
 
 class TCPServer:
-    def __init__(self, ip="0.0.0.0", port=4489):
+    def __init__(self, ip="127.0.0.1", port=4489):
         self.shutdown = False
         self.server = None
         self.file_path = "".join((os.path.dirname(os.path.abspath(__file__)),

--- a/tests/sender/local_servers.py
+++ b/tests/sender/local_servers.py
@@ -16,7 +16,7 @@ class SSLServer:
                                   os.sep))
         self.loop = asyncio.get_event_loop()
         self.server_process = multiprocessing.Process(target=self.server,
-                                                 name='sslserver')
+                                                      name='sslserver')
         self.server_process.start()
 
     def server(self):
@@ -30,7 +30,7 @@ class SSLServer:
                     assert len(data) > 0, repr(data)
                     writer.write(data)
                     yield from writer.drain()
-            except:
+            except Exception:
                 writer.close()
 
         server_cert = os.getenv('DEVO_SENDER_SERVER_CRT',

--- a/tests/sender/send_data.py
+++ b/tests/sender/send_data.py
@@ -86,7 +86,6 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
-                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender(engine_config)
@@ -108,7 +107,6 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
-                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender(engine_config, timeout=15)
@@ -132,7 +130,6 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
-                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender(engine_config)
@@ -157,7 +154,6 @@ class TestSender(unittest.TestCase):
             try:
                 engine_config = SenderConfigSSL(address=(self.server,
                                                          self.port),
-                                                sec_level=0,
                                                 check_hostname=False,
                                                 verify_mode=CERT_NONE)
                 con = Sender(engine_config)
@@ -178,7 +174,6 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
-                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
@@ -240,7 +235,6 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
-                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
@@ -271,7 +265,7 @@ class TestSender(unittest.TestCase):
             engine_config = {"address": self.server, "port": self.port,
                              "key": self.key, "cert": self.cert,
                              "chain": self.chain, "check_hostname": False,
-                             "verify_mode": CERT_NONE, "sec_level": 0}
+                             "verify_mode": CERT_NONE}
 
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
                                      level=TEST_FACILITY)

--- a/tests/sender/send_data.py
+++ b/tests/sender/send_data.py
@@ -5,7 +5,7 @@ from devo.sender import Sender, SenderConfigTCP, SenderConfigSSL
 from devo.common import get_log
 from .load_certs import *
 
-TEST_FACILITY = 1
+TEST_FACILITY = 10
 
 
 class TestSender(unittest.TestCase):
@@ -16,9 +16,9 @@ class TestSender(unittest.TestCase):
         to set it else the vars will need to be set
         up in any other way.
         """
-        self.server = os.getenv('DEVO_SENDER_SERVER', "0.0.0.0")
+        self.server = os.getenv('DEVO_SENDER_SERVER', "127.0.0.1")
         self.port = int(os.getenv('DEVO_SENDER_PORT', 4488))
-        self.tcp_server = os.getenv('DEVO_SENDER_TCP_SERVER', "0.0.0.0")
+        self.tcp_server = os.getenv('DEVO_SENDER_TCP_SERVER', "127.0.0.1")
         self.tcp_port = int(os.getenv('DEVO_SENDER_TCP_PORT', 4489))
 
         self.key = os.getenv('DEVO_SENDER_KEY', CLIENT_KEY)
@@ -86,12 +86,15 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
+                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender(engine_config)
             for i in range(self.default_numbers_sendings):
                 con.send(tag=self.my_app, msg=self.test_msg)
-                if len(con.socket.recv(5000)) == 0:
+                data_received = con.socket.recv(5000)
+                print(b"\n" + data_received)
+                if len(data_received) == 0:
                     raise Exception('Not msg sent!')
             con.close()
         except Exception as error:
@@ -105,14 +108,17 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
+                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender(engine_config, timeout=15)
             for i in range(self.default_numbers_sendings):
-                con.send(tag=self.my_bapp, msg=self.test_msg.encode("utf-8")
-                         , zip=True)
+                con.send(tag=self.my_bapp, msg=self.test_msg.encode("utf-8"),
+                         zip=True)
                 con.flush_buffer()
-                if len(con.socket.recv(1000)) == 0:
+                data_received = con.socket.recv(5000)
+                print(b"\n" + data_received)
+                if len(data_received) == 0:
                     raise Exception('Not msg sent!')
             con.close()
         except Exception as error:
@@ -126,6 +132,7 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
+                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender(engine_config)
@@ -134,8 +141,9 @@ class TestSender(unittest.TestCase):
 
             con.send(tag=self.my_app, msg=content, multiline=True)
             con.flush_buffer()
-
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
             con.close()
         except Exception as error:
@@ -149,6 +157,7 @@ class TestSender(unittest.TestCase):
             try:
                 engine_config = SenderConfigSSL(address=(self.server,
                                                          self.port),
+                                                sec_level=0,
                                                 check_hostname=False,
                                                 verify_mode=CERT_NONE)
                 con = Sender(engine_config)
@@ -169,6 +178,7 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
+                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
@@ -178,31 +188,41 @@ class TestSender(unittest.TestCase):
             print("Testing logger info")
             logger.info("Testing Sender inherit logging handler functio"
                         "nality... INFO - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger error")
             logger.error("Testing Sender inherit logging handler function"
                          "ality... ERROR - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger warning")
             logger.warning("Testing Sender inherit logging handler functio"
                            "nality... WARNING - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger debug")
             logger.debug("Testing Sender inherit logging handler functiona"
                          "lity... DEBUG - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger critical")
             logger.critical("Testing Sender inherit logging handler functio"
                             "nality... CRITICAL - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             con.close()
@@ -220,6 +240,7 @@ class TestSender(unittest.TestCase):
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
                                             chain=self.chain,
+                                            sec_level=0,
                                             check_hostname=False,
                                             verify_mode=CERT_NONE)
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
@@ -231,7 +252,9 @@ class TestSender(unittest.TestCase):
             # table
             con.info("Testing Sender default handler functionality in remote "
                      "table... INFO - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             con.close()
@@ -248,7 +271,7 @@ class TestSender(unittest.TestCase):
             engine_config = {"address": self.server, "port": self.port,
                              "key": self.key, "cert": self.cert,
                              "chain": self.chain, "check_hostname": False,
-                             "verify_mode": CERT_NONE}
+                             "verify_mode": CERT_NONE, "sec_level": 0}
 
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
                                      level=TEST_FACILITY)
@@ -258,31 +281,41 @@ class TestSender(unittest.TestCase):
             print("Testing logger info")
             logger.info("Testing Sender static handler functionality... "
                         "INFO - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger error")
             logger.error("Testing Sender static logging handler "
                          "functionality... ERROR - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger warning")
             logger.warning("Testing Sender static logging handler "
                            "functionality... WARNING - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger debug")
             logger.debug("Testing Sender static logging handler "
                          "functionality... DEBUG - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             print("Testing logger critical")
             logger.critical("Testing Sender static logging handler "
                             "functionality... CRITICAL - log")
-            if len(con.socket.recv(5000)) == 0:
+            data_received = con.socket.recv(5000)
+            print(b"\n" + data_received)
+            if len(data_received) == 0:
                 raise Exception('Not msg sent!')
 
             con.close()

--- a/tests/sender/send_data.py
+++ b/tests/sender/send_data.py
@@ -1,5 +1,6 @@
 import unittest
 import socket
+from ssl import CERT_NONE
 from devo.sender import Sender, SenderConfigTCP, SenderConfigSSL
 from devo.common import get_log
 from .load_certs import *
@@ -84,7 +85,9 @@ class TestSender(unittest.TestCase):
         try:
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
-                                            chain=self.chain)
+                                            chain=self.chain,
+                                            check_hostname=False,
+                                            verify_mode=CERT_NONE)
             con = Sender(engine_config)
             for i in range(self.default_numbers_sendings):
                 con.send(tag=self.my_app, msg=self.test_msg)
@@ -101,7 +104,9 @@ class TestSender(unittest.TestCase):
         try:
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
-                                            chain=self.chain)
+                                            chain=self.chain,
+                                            check_hostname=False,
+                                            verify_mode=CERT_NONE)
             con = Sender(engine_config, timeout=15)
             for i in range(self.default_numbers_sendings):
                 con.send(tag=self.my_bapp, msg=self.test_msg.encode("utf-8")
@@ -120,7 +125,9 @@ class TestSender(unittest.TestCase):
         try:
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
-                                            chain=self.chain)
+                                            chain=self.chain,
+                                            check_hostname=False,
+                                            verify_mode=CERT_NONE)
             con = Sender(engine_config)
             with open(self.test_file, 'r') as file:
                 content = file.read()
@@ -141,7 +148,9 @@ class TestSender(unittest.TestCase):
         if self.test_tcp == "True":
             try:
                 engine_config = SenderConfigSSL(address=(self.server,
-                                                         self.port))
+                                                         self.port),
+                                                check_hostname=False,
+                                                verify_mode=CERT_NONE)
                 con = Sender(engine_config)
                 for i in range(self.default_numbers_sendings):
                     con.send(tag=self.my_app, msg=self.test_msg)
@@ -159,7 +168,9 @@ class TestSender(unittest.TestCase):
         try:
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
-                                            chain=self.chain)
+                                            chain=self.chain,
+                                            check_hostname=False,
+                                            verify_mode=CERT_NONE)
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
                                      level=TEST_FACILITY)
             logger = get_log(name="DevoLogger", handler=con,
@@ -208,7 +219,9 @@ class TestSender(unittest.TestCase):
 
             engine_config = SenderConfigSSL(address=(self.server, self.port),
                                             key=self.key, cert=self.cert,
-                                            chain=self.chain)
+                                            chain=self.chain,
+                                            check_hostname=False,
+                                            verify_mode=CERT_NONE)
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
                                      level=TEST_FACILITY)
             # NOTE: this logger logging traces will be visible in console
@@ -234,7 +247,8 @@ class TestSender(unittest.TestCase):
         try:
             engine_config = {"address": self.server, "port": self.port,
                              "key": self.key, "cert": self.cert,
-                             "chain": self.chain}
+                             "chain": self.chain, "check_hostname": False,
+                             "verify_mode": CERT_NONE}
 
             con = Sender.for_logging(config=engine_config, tag=self.my_app,
                                      level=TEST_FACILITY)

--- a/tests/sender/send_lookup.py
+++ b/tests/sender/send_lookup.py
@@ -1,11 +1,12 @@
 import unittest
+from ssl import CERT_NONE
 from devo.sender import Sender, SenderConfigSSL, Lookup
 from .load_certs import *
 
 
 class TestLookup(unittest.TestCase):
     def setUp(self):
-        self.server = os.getenv('DEVO_SENDER_SERVER', "0.0.0.0")
+        self.server = os.getenv('DEVO_SENDER_SERVER', "127.0.0.1")
         self.port = int(os.getenv('DEVO_SENDER_PORT', 4488))
 
         self.key = os.getenv('DEVO_SENDER_KEY', CLIENT_KEY)
@@ -22,7 +23,10 @@ class TestLookup(unittest.TestCase):
 
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
-                                        chain=self.chain)
+                                        chain=self.chain,
+                                        sec_level=0,
+                                        check_hostname=False,
+                                        verify_mode=CERT_NONE)
         con = Sender(engine_config)
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
 
@@ -39,7 +43,10 @@ class TestLookup(unittest.TestCase):
     def test_ssl_lookup_new_line(self):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
-                                        chain=self.chain)
+                                        chain=self.chain,
+                                        sec_level=0,
+                                        check_hostname=False,
+                                        verify_mode=CERT_NONE)
         con = Sender(engine_config)
 
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
@@ -60,7 +67,10 @@ class TestLookup(unittest.TestCase):
     def test_ssl_lookup_override(self):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
-                                        chain=self.chain)
+                                        chain=self.chain,
+                                        sec_level=0,
+                                        check_hostname=False,
+                                        verify_mode=CERT_NONE)
         con = Sender(engine_config)
 
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
@@ -81,7 +91,10 @@ class TestLookup(unittest.TestCase):
     def test_ssl_lookup_delete_line(self):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
-                                        chain=self.chain)
+                                        chain=self.chain,
+                                        sec_level=0,
+                                        check_hostname=False,
+                                        verify_mode=CERT_NONE)
         con = Sender(engine_config)
 
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
@@ -102,7 +115,10 @@ class TestLookup(unittest.TestCase):
     def test_ssl_lookup_simplify(self):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
-                                        chain=self.chain)
+                                        chain=self.chain,
+                                        sec_level=0,
+                                        check_hostname=False,
+                                        verify_mode=CERT_NONE)
         con = Sender(engine_config)
 
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)

--- a/tests/sender/send_lookup.py
+++ b/tests/sender/send_lookup.py
@@ -24,7 +24,6 @@ class TestLookup(unittest.TestCase):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
                                         chain=self.chain,
-                                        sec_level=0,
                                         check_hostname=False,
                                         verify_mode=CERT_NONE)
         con = Sender(engine_config)
@@ -44,7 +43,6 @@ class TestLookup(unittest.TestCase):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
                                         chain=self.chain,
-                                        sec_level=0,
                                         check_hostname=False,
                                         verify_mode=CERT_NONE)
         con = Sender(engine_config)
@@ -68,7 +66,6 @@ class TestLookup(unittest.TestCase):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
                                         chain=self.chain,
-                                        sec_level=0,
                                         check_hostname=False,
                                         verify_mode=CERT_NONE)
         con = Sender(engine_config)
@@ -92,7 +89,6 @@ class TestLookup(unittest.TestCase):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
                                         chain=self.chain,
-                                        sec_level=0,
                                         check_hostname=False,
                                         verify_mode=CERT_NONE)
         con = Sender(engine_config)
@@ -116,7 +112,6 @@ class TestLookup(unittest.TestCase):
         engine_config = SenderConfigSSL(address=(self.server, self.port),
                                         key=self.key, cert=self.cert,
                                         chain=self.chain,
-                                        sec_level=0,
                                         check_hostname=False,
                                         verify_mode=CERT_NONE)
         con = Sender(engine_config)


### PR DESCRIPTION
### Added
 * Support for Python 3.8
 * Testing in Travis for python 3.6, 3.7 and 3.8
 * Support in API to timeZone flag for Devo API
 * Support in API for new devo custom formats
 * Documentation for new date formats
 * Functions to change buffer size and compression_level of Sender
 * Support for zip, buffer and compression_level flags in Sender CLI

 
### Changed
 * SSL Server support to adapt it from python 3.5 to python 3.8
 * SSL Send data tests 
 * Requirements, updated.
 
#### Removed
 * unnecessary elifs in code following PEP8 recomendations