### PR TITLE
[3.4.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [3.3.7] - 
+## [3.4.0] - 2020-08-06
+### Added
+ * Support to use in lookup fields lists: ints, booleans and floats. Not necessary send all with str type.
+ * More documentation in lookup readme
+ 
+## [3.3.7] - 2020-07-16
 ### Fixed
  * Problem in list_to_headers when pass key but not key_index
  * Count of sended events when zip=True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  
 ### Changed
  * Updated message when overwrite sec_level to show only when create Sender
+ * Updated test for bad credentials. Now api returns error in signature validation
 
 ## [3.4.0] - 2020-08-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [3.4.1] - 2020-11-03
+### Added
+ * Info about use custom CA for verify certificates in client
+ 
 ### Fixed
  * Client problems with default "From" key for queries
  * Socket closes are more gently now, fixed problems with loss events
+ 
+### Changed
+ * Updated message when overwrite sec_level to show only when create Sender
 
 ## [3.4.0] - 2020-08-06
 ### Added
@@ -64,7 +70,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * Functions to change buffer size and compression_level of Sender
  * Support for zip, buffer and compression_level flags in Sender CLI
 
- 
 ### Changed
  * SSL Server support to adapt it from python 3.5 to python 3.8
  * SSL Send data tests 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [3.4.1] - 2020-11-03
+### Fixed
+ * Client problems with default "From" key for queries
+ * Socket closes are more gently now, fixed problems with loss events
+
 ## [3.4.0] - 2020-08-06
 ### Added
  * Support to use in lookup fields lists: ints, booleans and floats. Not necessary send all with str type.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![master Build Status](https://travis-ci.com/DevoInc/python-sdk.svg?branch=master)](https://travis-ci.com/DevoInc/python-sdk) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-sdk/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.4.0-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.4.1-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
 
 
 # Devo Python SDK

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![master Build Status](https://travis-ci.com/DevoInc/python-sdk.svg?branch=master)](https://travis-ci.com/DevoInc/python-sdk) [![LICENSE](https://img.shields.io/dub/l/vibe-d.svg)](https://github.com/DevoInc/python-sdk/blob/master/LICENSE)
 
-[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.3.7-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
+[![wheel](https://img.shields.io/badge/wheel-yes-brightgreen.svg)](https://pypi.org/project/devo-sdk/) [![version](https://img.shields.io/badge/version-3.4.0-blue.svg)](https://pypi.org/project/devo-sdk/) [![python](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue.svg)](https://pypi.org/project/devo-sdk/)
 
 
 # Devo Python SDK

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "3.3.7"
+__version__ = "3.4.0"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -28,8 +28,8 @@ ERROR_MSGS = {
     "no_query": "Error: Not query provided.",
     "no_auth": "Client dont have key&secret or auth token/jwt",
     "no_endpoint": "Endpoint 'address' not found",
-    "to_but_no_from": "If you use end dates for the query 'to' it is necessary "
-                      "to use start date 'from'"
+    "to_but_no_from": "If you use end dates for the query 'to' it is "
+                      "necessary to use start date 'from'"
 }
 
 

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -27,7 +27,9 @@ SIMPLECOMPACT_TO_ARRAY = "jsoncompactsimple_to_array"
 ERROR_MSGS = {
     "no_query": "Error: Not query provided.",
     "no_auth": "Client dont have key&secret or auth token/jwt",
-    "no_endpoint": "Endpoint 'address' not found"
+    "no_endpoint": "Endpoint 'address' not found",
+    "to_but_no_from": "If you use end dates for the query 'to' it is necessary "
+                      "to use start date 'from'"
 }
 
 

--- a/devo/api/scripts/client_cli.py
+++ b/devo/api/scripts/client_cli.py
@@ -74,13 +74,20 @@ def query(**kwargs):
             return
         exit()
 
-    dates = {}
-    if "to" in config.keys():
-        dates["from"] = config['from']
-    if "to" in config.keys():
-        dates["to"] = config['to']
-    if "timeZone" in config.keys():
-        dates['timeZone'] = config['timeZone']
+    if "from" in config.keys():
+        dates = {'from': config['from']}
+        if "to" in config.keys():
+            dates["to"] = config['to']
+        if "timeZone" in config.keys():
+            dates['timeZone'] = config['timeZone']
+    elif "to" in config.keys():
+        print_error(ERROR_MSGS['to_but_no_from'], show_help=True)
+        exit()
+    else:
+        if "timeZone" in config.keys():
+            dates = {'timeZone': config['timeZone']}
+        else:
+            dates = None
 
     reponse = api.query(query=config['query'], dates=dates)
 

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -131,8 +131,16 @@ class Sender(logging.Handler):
             get_log(handler=get_stream_handler(
                 msg_format='%(asctime)s|%(levelname)s|Devo-Sender|%(message)s'))
 
-        self.socket = None
         self._sender_config = config
+
+        if self._sender_config.sec_level is not None:
+            self.logger.warning("Openssl's default security "
+                                "level has been overwritten to "
+                                "{}.".format(self.
+                                             _sender_config.
+                                             sec_level))
+
+        self.socket = None
         self.reconnection = 0
         self.debug = debug
         self.socket_timeout = timeout
@@ -201,11 +209,6 @@ class Sender(logging.Handler):
                         cafile=self._sender_config.chain)
 
                     if self._sender_config.sec_level is not None:
-                        self.logger.warning("Openssl's default security "
-                                            "level has been overwritten to "
-                                            "{}.".format(self.
-                                                         _sender_config.
-                                                         sec_level))
                         context.set_ciphers(
                             "DEFAULT@SECLEVEL={!s}"
                             .format(self._sender_config.sec_level))

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -89,6 +89,7 @@ class SenderConfigTCP:
         try:
             self.address = address
             self.hostname = socket.gethostname()
+            self.sec_level = None
         except Exception as error:
             raise DevoSenderException(
                 "DevoSenderConfigTCP|Can't create TCP config: "

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -343,7 +343,7 @@ class Sender(logging.Handler):
         Forces socket closure
         """
         if self.socket is not None:
-            self.socket.shuwdown(2)
+            self.socket.shutdown(2)
             self.socket.close()
             self.socket = None
 

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -340,6 +340,7 @@ class Sender(logging.Handler):
         Forces socket closure
         """
         if self.socket is not None:
+            self.socket.shuwdown(2)
             self.socket.close()
             self.socket = None
 

--- a/devo/sender/lookup.py
+++ b/devo/sender/lookup.py
@@ -404,10 +404,14 @@ class Lookup:
         :param str field: field for clean
         :return str: cleaned field
         """
+        if not isinstance(field, (str, bytes)):
+            return field
+
         field = field.strip()
-        if not Lookup.is_number(field):
-            field = '"%s"' % field
-        return field
+        if Lookup.is_number(field):
+            return field
+
+        return '"%s"' % field
 
     @staticmethod
     def is_number(text=""):

--- a/devo/sender/lookup.py
+++ b/devo/sender/lookup.py
@@ -260,7 +260,7 @@ class Lookup:
 
         >>>row = Lookup.list_to_fields(fields, "23")
         >>>obj.send_data(row)
-        :param row: row to send
+        :param row: row t   o send
         :param delete: True or False. Its true, delete row with same key
         :return:
         """

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -164,6 +164,25 @@ You can revert it with:
 api.verify_certificates(True)
 ```  
 
+## Use custom CA to verify
+For customs servers, and custom certificates, you can use custom CA for verity that certificates. 
+You can put CA cert path instead of "False" or "True"
+
+```python
+from devo.api import Client, ClientConfig
+
+
+api = Client(auth= {"key":"myapikey", "secret":"myapisecret"}, 
+             address="https://apiv2-eu.devo.com/search/query")
+api.verify_certificates("/path/to/cafile.ca")
+```
+
+You can revert it with:
+
+```python
+api.verify_certificates(True)
+```  
+
 ## Processors flags:
 
 By default, you receive response in str/bytes (Depends of your python version) direct from Socket, and you need manipulate the data.

--- a/docs/api/destination_email.md
+++ b/docs/api/destination_email.md
@@ -4,7 +4,9 @@ API have a email destination to send query results by email.
 
 ## How to use
 
-As any query you must to add 'query', 'from' and 'to' date params. But It's not necessary add mode.type parameter because all response format will be csv. In a future will have support for more format, **if you need more format please request us**.
+As any query you must to add 'query', 'from' and 'to' date params. But It's not necessary add mode.type parameter 
+because all response format will be csv. In a future will have support for more format, 
+**if you need more format please request us**.
 
 To use 'email' destination you must add destination parameter with type 'email' (see example).
 
@@ -29,28 +31,26 @@ To use 'email' destination you must add destination parameter with type 'email' 
 
 ## Example
 
-```python
-from devo.api import Client
+```pyton
+api = Client(auth={"key": "myapikey",
+                   "secret": "myapisecret"},
+             address="https://apiv2-eu.devo.com/search/query",
+             config=ClientConfig(response="json", stream=False, processor=JSON,
+                                 destination={
+                                     "type": "email",
+                                     "params": {
+                                         "email.to": "user@devo.com",
+                                         "email.subject": "Api v2 Test",
+                                         "format": "gzip",
+                                     },
+                                 }))
 
-api = Client(key="myapikey",
-              secret="myapisecret",
-              url="https://apiv2-eu.devo.com/search/query",
-              user="user@devo.com",
-              app_name="testing app")
-              
-              
-response = api.query("from siem.logtrust.web.activity select *", 
-                     dates={"from":"yesterday()", "to": "now()"}, 
-                     destination= { 
-                     "type":"email",
-                     "params":{
-                       "email.to":"email@domain.com",
-                       "email.subject":"Api v2 Test",
-                       "retention.time":300000,
-                       "format":"gzip",
-                       },
-                     })
+
+response = api.query("from siem.logtrust.web.activity select * limit 10",
+                     dates={"from": "yesterday()", "to": "now()"})
+
 ```
+
 
 ## Result 
 

--- a/docs/api/destination_redis.md
+++ b/docs/api/destination_redis.md
@@ -31,40 +31,39 @@ This destination have 2 modes:
 
 ### Example
 
-```python
-from devo.api import Client
 
-api = Client(key="myapikey",
-              secret="myapisecret",
-              url="https://apiv2-eu.devo.com/search/query",
-              user="user@devo.com",
-              app_name="testing app")
-              
-              
-response = api.query("from siem.logtrust.web.activity select *", 
-                     dates={"from":"yesterday()", "to": "now()"}, 
-                     destination= { 
-                     "type":"email",
-                     "params":{
-                          "friendlyName":"redis-rresino-154q", 
-                            "description": "description of task",
-                            "expireIn": 30000,
-                            "keyFields": [{
-                                "name": "domain",
-                                "type": "str"
-                            }, {
-                                "name": "username",
-                                "type": "str"
-                            }],
-                            "valueFields": [{
-                                "name": "domain",
-                                "type": "str"
-                            }, {
-                                "name": "username",
-                                "type": "str"
-                            }]
-                        },
-                     })
+```pyton
+api = Client(auth={"key": "myapikey",
+                   "secret": "myapisecret"},
+             address="https://apiv2-eu.devo.com/search/query",
+             config=ClientConfig(response="json", stream=False, processor=JSON,
+                                 destination= { 
+                                     "type":"redis",
+                                     "params":{
+                                          "friendlyName":"redis-rresino-154q", 
+                                            "description": "description of task",
+                                            "expireIn": 30000,
+                                            "keyFields": [{
+                                                "name": "domain",
+                                                "type": "str"
+                                            }, {
+                                                "name": "username",
+                                                "type": "str"
+                                            }],
+                                            "valueFields": [{
+                                                "name": "domain",
+                                                "type": "str"
+                                            }, {
+                                                "name": "username",
+                                                "type": "str"
+                                            }]
+                                        },
+                                     }))
+
+
+response = api.query("from siem.logtrust.web.activity select * limit 10",
+                     dates={"from": "yesterday()", "to": "now()"})
+
 ```
 
 ## Results

--- a/docs/api/destination_s3.md
+++ b/docs/api/destination_s3.md
@@ -24,28 +24,27 @@ To use 's3' destination you must add destination parameter with type 's3' (see e
 
 ## Example
 
-```python
-from devo.api import Client
 
-api = Client(key="myapikey",
-              secret="myapisecret",
-              url="https://apiv2-eu.devo.com/search/query",
-              user="user@devo.com",
-              app_name="testing app")
-              
-              
-response = api.query("from siem.logtrust.web.activity select *", 
-                     dates={"from":"yesterday()", "to": "now()"}, 
-                     destination= { 
-                     "type":"s3",
-                     "params":{
-                            "aws.bucket": "blu-2223",
-                            "aws.region": "eu-west-1",
-                            "aws.accesskey": "AKI*************",
-                            "aws.secretkey": "T********/**********15tpn3***V2UZ",
-                            "format": "zip"
-                        },
-                     })
+```pyton
+api = Client(auth={"key": "myapikey",
+                   "secret": "myapisecret"},
+             address="https://apiv2-eu.devo.com/search/query",
+             config=ClientConfig(response="json", stream=False, processor=JSON,
+                                 destination= { 
+                                     "type":"s3",
+                                     "params":{
+                                            "aws.bucket": "blu-2223",
+                                            "aws.region": "eu-west-1",
+                                            "aws.accesskey": "AKI*************",
+                                            "aws.secretkey": "T********/**********15tpn3***V2UZ",
+                                            "format": "zip"
+                                        },
+                                     }))
+
+
+response = api.query("from siem.logtrust.web.activity select * limit 10",
+                     dates={"from": "yesterday()", "to": "now()"})
+
 ```
 
 ## Results

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -53,14 +53,17 @@ Params
 
 + headers **(_list_ required)**: column names list of the lookup
 + type_of_key **(_string_ optional)**: specify a concrete type for the key (Default string)
-+ key **(_string_ optional)**: name of key
++ key **(_string_ optional)**: name of key **deprecated, not recommended, use key_index**
 + key_index **(_string_ optional)**: index of key. You can use this or key
 + types **(_list_ optional')**: list of type:  with types of columns in order
 
 Accepted types:
  - String -> "str"
- - Integer -> "int"
+ - Integer -> "int" (default int type: int8)
+ - Integer4 -> "int4"
+ - Integer8 -> "int8"
  - Float -> "float"
+ - Boolean -> "bool"
  - IP -> "ip4"
 
 
@@ -101,7 +104,7 @@ You can use _send_headers_ method of _LtLookup_ class we can unify _list_to_head
 
 _send_headers_ Params
 + headers **(_list_ default: [] )**: column name list of lookup 
-+ key **(_string_ default 'KEY')**: column name of key
++ key **(_string_ default 'KEY')**: column name of key **deprecated, not recommended, use key_index**
 + key_index **(_string_ default 'KEY')**: column name of key
 + event **(_string_ default: 'START')**: header event
     - START: start of header
@@ -120,9 +123,9 @@ Finally, to send a new row we can use _send_data_line_ method from _LtLooup_ cla
 
 Params
 
-+ key **(_string_ optional default: None)**: key value
++ key **(_string_ optional default: None)**: key value **deprecated, not recommended, use key_index**
 + key_index **(_string_ optional default: None)**: or key index in list fields
-+ fields **(_list_ default: [])**: values list
++ fields **(_list_ default: [])**: values list: can be str, int, float and bool
 + delete **(_boolean_ default: False)**: row must be deleted
 
 Example:
@@ -145,7 +148,7 @@ lookup.send_control(event='START', headers=pHeaders, action='INC')
 # You can use key value
 lookup.send_data_line(key="11", fields=["11", "HEX11", "COLOR11" ])
 # Or you can use key_index (Position in list)
-lookup.send_data_line(key_index=0, fields=["22", "HEX22", "COLOR22" ])
+lookup.send_data_line(key_index=0, fields=[22, "HEX22", "COLOR22"])
 lookup.send_control(event='END', headers=pHeaders, action='INC')
 
 con.socket.shutdown(0)
@@ -212,3 +215,13 @@ lookup.send_csv(path=conf.get('lookup').get('file', "example.csv"),
                 has_header=True, key=conf.get('lkey', "ID"))
 con.socket.shutdown(0)
 ````
+
+You can use config file to send types list:
+
+```
+{
+ 'lookup' : {
+    'types': ["int", "str", "int4", "bool", "int8"]
+    ....
+ }}
+```

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -53,7 +53,7 @@ Params
 
 + headers **(_list_ required)**: column names list of the lookup
 + type_of_key **(_string_ optional)**: specify a concrete type for the key (Default string)
-+ key **(_string_ optional)**: name of key **deprecated, not recommended, use key_index**
++ key **(_string_ optional)**: name of key **deprecated, not recommended. Use key_index instead**
 + key_index **(_string_ optional)**: index of key. You can use this or key
 + types **(_list_ optional')**: list of type:  with types of columns in order
 
@@ -104,7 +104,7 @@ You can use _send_headers_ method of _LtLookup_ class we can unify _list_to_head
 
 _send_headers_ Params
 + headers **(_list_ default: [] )**: column name list of lookup 
-+ key **(_string_ default 'KEY')**: column name of key **deprecated, not recommended, use key_index**
++ key **(_string_ default 'KEY')**: column name of key **deprecated, not recommended. Use key_index instead**
 + key_index **(_string_ default 'KEY')**: column name of key
 + event **(_string_ default: 'START')**: header event
     - START: start of header

--- a/tests/api/cli.py
+++ b/tests/api/cli.py
@@ -34,31 +34,31 @@ class TestApi(unittest.TestCase):
         result = runner.invoke(query, [])
         self.assertIn(ERROR_MSGS['no_endpoint'], result.stdout)
 
-    # def test_not_credentials(self):
-    #     runner = CliRunner()
-    #     result = runner.invoke(query, ["--debug",
-    #                                    "--from", "2018-01-01",
-    #                                    "--query", "from demo.ecommerce.data "
-    #                                               "select timestamp limit 1",
-    #                                    "--address", self.uri])
-    #
-    #     self.assertIsInstance(result.exception, DevoClientException)
-    #     self.assertEqual(result.exception.args[0]['status'], 500)
-    #     self.assertIn(ERROR_MSGS['no_auth'],
-    #                   result.exception.args[0]['object'])
-    #
-    # def test_bad_url(self):
-    #     runner = CliRunner()
-    #     result = runner.invoke(query, ["--debug",
-    #                                    "--from", "2018-01-01",
-    #                                    "--query", "from demo.ecommerce.data "
-    #                                               "select timestamp limit 1",
-    #                                    "--address", "error-apiv2-us.logtrust"
-    #                                             ".com/search/query",
-    #                                    "--key", self.key,
-    #                                    "--secret", self.secret])
-    #     self.assertIsInstance(result.exception, DevoClientException)
-    #     self.assertEqual(result.exception.args[0]['status'], 500)
+    def test_not_credentials(self):
+        runner = CliRunner()
+        result = runner.invoke(query, ["--debug",
+                                       "--from", "2018-01-01",
+                                       "--query", "from demo.ecommerce.data "
+                                                  "select timestamp limit 1",
+                                       "--address", self.uri])
+
+        self.assertIsInstance(result.exception, DevoClientException)
+        self.assertEqual(result.exception.args[0]['status'], 500)
+        self.assertIn(ERROR_MSGS['no_auth'],
+                      result.exception.args[0]['object'])
+
+    def test_bad_url(self):
+        runner = CliRunner()
+        result = runner.invoke(query, ["--debug",
+                                       "--from", "2018-01-01",
+                                       "--query", "from demo.ecommerce.data "
+                                                  "select timestamp limit 1",
+                                       "--address", "error-apiv2-us.logtrust"
+                                                ".com/search/query",
+                                       "--key", self.key,
+                                       "--secret", self.secret])
+        self.assertIsInstance(result.exception, DevoClientException)
+        self.assertEqual(result.exception.args[0]['status'], 500)
 
     def test_bad_credentials(self):
         runner = CliRunner()
@@ -71,37 +71,37 @@ class TestApi(unittest.TestCase):
                                        "--secret", self.secret])
 
         self.assertIsInstance(result.exception, DevoClientException)
-        self.assertEqual(result.exception.args[0]['status'], 401)
-    #
-    # def test_normal_query(self):
-    #     runner = CliRunner()
-    #     result = runner.invoke(query, ["--debug",
-    #                                    "--from", "2018-01-01",
-    #                                    "--query", "from demo.ecommerce.data "
-    #                                               "select timestamp limit 1",
-    #                                    "--address", self.uri,
-    #                                    "--key", self.key,
-    #                                    "--secret", self.secret])
-    #
-    #     self.assertIsNone(result.exception)
-    #     self.assertEqual(result.exit_code, 0)
-    #     self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
-    #                   result.output)
-    #
-    # def test_with_config_file(self):
-    #     if self.config_path:
-    #         runner = CliRunner()
-    #         result = runner.invoke(query, ["--debug",
-    #                                        "--from", "2018-01-01",
-    #                                        "--query",
-    #                                        "from demo.ecommerce.data "
-    #                                        "select timestamp limit 1",
-    #                                        "--config", self.config_path])
-    #
-    #         self.assertIsNone(result.exception)
-    #         self.assertEqual(result.exit_code, 0)
-    #         self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
-    #                       result.output)
+        self.assertEqual(result.exception.args[0]['error']['code'], 12)
+
+    def test_normal_query(self):
+        runner = CliRunner()
+        result = runner.invoke(query, ["--debug",
+                                       "--from", "2018-01-01",
+                                       "--query", "from demo.ecommerce.data "
+                                                  "select timestamp limit 1",
+                                       "--address", self.uri,
+                                       "--key", self.key,
+                                       "--secret", self.secret])
+
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
+                      result.output)
+
+    def test_with_config_file(self):
+        if self.config_path:
+            runner = CliRunner()
+            result = runner.invoke(query, ["--debug",
+                                           "--from", "2018-01-01",
+                                           "--query",
+                                           "from demo.ecommerce.data "
+                                           "select timestamp limit 1",
+                                           "--config", self.config_path])
+
+            self.assertIsNone(result.exception)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
+                          result.output)
 
 
 if __name__ == '__main__':

--- a/tests/api/cli.py
+++ b/tests/api/cli.py
@@ -34,31 +34,31 @@ class TestApi(unittest.TestCase):
         result = runner.invoke(query, [])
         self.assertIn(ERROR_MSGS['no_endpoint'], result.stdout)
 
-    def test_not_credentials(self):
-        runner = CliRunner()
-        result = runner.invoke(query, ["--debug",
-                                       "--from", "2018-01-01",
-                                       "--query", "from demo.ecommerce.data "
-                                                  "select timestamp limit 1",
-                                       "--address", self.uri])
-
-        self.assertIsInstance(result.exception, DevoClientException)
-        self.assertEqual(result.exception.args[0]['status'], 500)
-        self.assertIn(ERROR_MSGS['no_auth'],
-                      result.exception.args[0]['object'])
-
-    def test_bad_url(self):
-        runner = CliRunner()
-        result = runner.invoke(query, ["--debug",
-                                       "--from", "2018-01-01",
-                                       "--query", "from demo.ecommerce.data "
-                                                  "select timestamp limit 1",
-                                       "--address", "error-apiv2-us.logtrust"
-                                                ".com/search/query",
-                                       "--key", self.key,
-                                       "--secret", self.secret])
-        self.assertIsInstance(result.exception, DevoClientException)
-        self.assertEqual(result.exception.args[0]['status'], 500)
+    # def test_not_credentials(self):
+    #     runner = CliRunner()
+    #     result = runner.invoke(query, ["--debug",
+    #                                    "--from", "2018-01-01",
+    #                                    "--query", "from demo.ecommerce.data "
+    #                                               "select timestamp limit 1",
+    #                                    "--address", self.uri])
+    #
+    #     self.assertIsInstance(result.exception, DevoClientException)
+    #     self.assertEqual(result.exception.args[0]['status'], 500)
+    #     self.assertIn(ERROR_MSGS['no_auth'],
+    #                   result.exception.args[0]['object'])
+    #
+    # def test_bad_url(self):
+    #     runner = CliRunner()
+    #     result = runner.invoke(query, ["--debug",
+    #                                    "--from", "2018-01-01",
+    #                                    "--query", "from demo.ecommerce.data "
+    #                                               "select timestamp limit 1",
+    #                                    "--address", "error-apiv2-us.logtrust"
+    #                                             ".com/search/query",
+    #                                    "--key", self.key,
+    #                                    "--secret", self.secret])
+    #     self.assertIsInstance(result.exception, DevoClientException)
+    #     self.assertEqual(result.exception.args[0]['status'], 500)
 
     def test_bad_credentials(self):
         runner = CliRunner()
@@ -72,36 +72,36 @@ class TestApi(unittest.TestCase):
 
         self.assertIsInstance(result.exception, DevoClientException)
         self.assertEqual(result.exception.args[0]['status'], 401)
-
-    def test_normal_query(self):
-        runner = CliRunner()
-        result = runner.invoke(query, ["--debug",
-                                       "--from", "2018-01-01",
-                                       "--query", "from demo.ecommerce.data "
-                                                  "select timestamp limit 1",
-                                       "--address", self.uri,
-                                       "--key", self.key,
-                                       "--secret", self.secret])
-
-        self.assertIsNone(result.exception)
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
-                      result.output)
-
-    def test_with_config_file(self):
-        if self.config_path:
-            runner = CliRunner()
-            result = runner.invoke(query, ["--debug",
-                                           "--from", "2018-01-01",
-                                           "--query",
-                                           "from demo.ecommerce.data "
-                                           "select timestamp limit 1",
-                                           "--config", self.config_path])
-
-            self.assertIsNone(result.exception)
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
-                          result.output)
+    #
+    # def test_normal_query(self):
+    #     runner = CliRunner()
+    #     result = runner.invoke(query, ["--debug",
+    #                                    "--from", "2018-01-01",
+    #                                    "--query", "from demo.ecommerce.data "
+    #                                               "select timestamp limit 1",
+    #                                    "--address", self.uri,
+    #                                    "--key", self.key,
+    #                                    "--secret", self.secret])
+    #
+    #     self.assertIsNone(result.exception)
+    #     self.assertEqual(result.exit_code, 0)
+    #     self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
+    #                   result.output)
+    #
+    # def test_with_config_file(self):
+    #     if self.config_path:
+    #         runner = CliRunner()
+    #         result = runner.invoke(query, ["--debug",
+    #                                        "--from", "2018-01-01",
+    #                                        "--query",
+    #                                        "from demo.ecommerce.data "
+    #                                        "select timestamp limit 1",
+    #                                        "--config", self.config_path])
+    #
+    #         self.assertIsNone(result.exception)
+    #         self.assertEqual(result.exit_code, 0)
+    #         self.assertIn('{"m":{"timestamp":{"type":"str","index":0',
+    #                       result.output)
 
 
 if __name__ == '__main__':

--- a/tests/common/date_parser.py
+++ b/tests/common/date_parser.py
@@ -16,8 +16,9 @@ class TestDateParser(unittest.TestCase):
         self.assertTrue(ts1 == ts2)
 
     def test_default_from(self):
-        ts1 = default_from()
-        ts2 = int((dt.utcnow() - self.epoch).total_seconds() * 1000) - 86400000
+        ts1 = str(default_from())[:11]
+        ts2 = str(int((dt.utcnow() - self.epoch).total_seconds() * 1000)
+                  - 86400000)[:11]
         self.assertTrue(ts1 == ts2)
 
     # Tests amounts

--- a/tests/common/date_parser.py
+++ b/tests/common/date_parser.py
@@ -11,8 +11,8 @@ class TestDateParser(unittest.TestCase):
     # --------------------------------------------------------------------------
 
     def test_default_to(self):
-        ts1 = default_to()
-        ts2 = int((dt.utcnow() - self.epoch).total_seconds() * 1000)
+        ts1 = str(default_to())[:11]
+        ts2 = str((dt.utcnow() - self.epoch).total_seconds() * 1000)[:11]
         self.assertTrue(ts1 == ts2)
 
     def test_default_from(self):

--- a/tests/sender/cli.py
+++ b/tests/sender/cli.py
@@ -59,6 +59,22 @@ class TestSender(unittest.TestCase):
         self.assertIn("Name or service not known",
                          result.exception.args[0])
 
+    # def test_bad_address(self):
+    #     runner = CliRunner()
+    #     result = runner.invoke(data, ["--debug",
+    #                                   "--address", "us.devoasd.com",
+    #                                   "--port", self.port,
+    #                                   "--key", self.key,
+    #                                   "--cert", self.cert,
+    #                                   "--chain", self.chain,
+    #                                   "--tag", self.my_app,
+    #                                   "--verify_mode", 0,
+    #                                   '--check_hostname', False,
+    #                                   "--line", "Test line"])
+    #
+    #     self.assertIsNone(result.exception)
+    #     self.assertGreater(int(result.output.split("Sended: ")[-1]), 0)
+
     def test_bad_certs(self):
         runner = CliRunner()
         result = runner.invoke(data, ["--debug",

--- a/tests/sender/cli.py
+++ b/tests/sender/cli.py
@@ -50,14 +50,14 @@ class TestSender(unittest.TestCase):
         result = runner.invoke(data, [])
         self.assertIn('No address', result.stdout)
 
-    def test_bad_address(self):
-        runner = CliRunner()
-        result = runner.invoke(data, ["--debug",
-                                      "--address", self.address + "asd"])
-
-        self.assertIsInstance(result.exception, DevoSenderException)
-        self.assertIn("Name or service not known",
-                         result.exception.args[0])
+    # def test_bad_address(self):
+    #     runner = CliRunner()
+    #     result = runner.invoke(data, ["--debug",
+    #                                   "--address", self.address + "asd"])
+    #
+    #     self.assertIsInstance(result.exception, DevoSenderException)
+    #     self.assertIn("Name or service not known",
+    #                      result.exception.args[0])
 
     # def test_bad_address(self):
     #     runner = CliRunner()


### PR DESCRIPTION
## [3.4.1] - 2020-11-03
### Added
 * Info about use custom CA for verify certificates in client
 
### Fixed
 * Client problems with default "From" key for queries
 * Socket closes are more gently now, fixed problems with loss events
 
### Changed
 * Updated message when overwrite sec_level to show only when create Sender
 * Updated test for bad credentials. Now api returns error in signature validation

## [3.4.0] - 2020-08-06
### Added
 * Support to use in lookup fields lists: ints, booleans and floats. Not necessary send all with str type.
 * More documentation in lookup readme