### PR TITLE
fix: remove sender's endpoint for AWS CA cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ To send data with Devo SDK, first choose the required endpoint depending on the 
 | Region 	| Endpoint                  	| Port 	|
 |--------	|---------------------------	|------	|
 | USA    	| us.elb.relay.logtrust.net 	| 443  	|
-| Canada 	| ca.elb.relay.logtrust.net 	| 443  	|
 | Europe 	| eu.elb.relay.logtrust.net 	| 443  	|
 | VDC    	| es.elb.relay.logtrust.net 	| 443  	|
 

--- a/docs/sender/sender.md
+++ b/docs/sender/sender.md
@@ -20,7 +20,6 @@ To send data with Devo SDK, first choose the required endpoint depending on the 
 | Region 	| Endpoint                  	| Port 	|
 |--------	|---------------------------	|------	|
 | USA    	| us.elb.relay.logtrust.net 	| 443  	|
-| Canada 	| ca.elb.relay.logtrust.net 	| 443  	|
 | Europe 	| eu.elb.relay.logtrust.net 	| 443  	|
 | VDC    	| es.elb.relay.logtrust.net 	| 443  	|
     


### PR DESCRIPTION
Apparently, for now, this is not ready (yet)