### PR TITLE
feat(lookups): new parameter for lookup operations that escapes double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add `type_of_key` parameter to `Lookup.send_headers` method
 * Avoid lookups' key element to be deleted when `Lookup.send_data_line` is invoked.
 
+## [3.4.3] - 2022-01-03
+### Added
+ * Double quotes on lookups can be escaped by adding `"escape_quotes": true` to the config file.
 
 ## [3.4.2] - 2021-05-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `Lookup.send_headers` method not working as expected with key_index parameter
 * Add `type_of_key` parameter to `Lookup.send_headers` method
 * Avoid lookups' key element to be deleted when `Lookup.send_data_line` is invoked.
-
-## [3.4.3] - 2022-01-03
 ### Added
  * Double quotes on lookups can be escaped by adding `"escape_quotes": true` to the config file.
 

--- a/devo/sender/lookup.py
+++ b/devo/sender/lookup.py
@@ -210,9 +210,10 @@ class Lookup:
                 if delete_index is not None:
                     for fields in spam_reader:
                         field_action = fields.pop(delete_index)
-                        p_fields = Lookup.process_fields(fields=fields,
-                                                         key_index=key_index,
-                                                         escape_quotes=self.escape_quotes)
+                        p_fields = Lookup.process_fields(
+                            fields=fields,
+                            key_index=key_index,
+                            escape_quotes=self.escape_quotes)
                         self.send_data(row=p_fields,
                                        delete=field_action == "delete"
                                        or field_action == "DELETE")
@@ -223,9 +224,10 @@ class Lookup:
                         counter += 1
                 else:
                     for fields in spam_reader:
-                        p_fields = Lookup.process_fields(fields=fields,
-                                                         key_index=key_index,
-                                                         escape_quotes=self.escape_quotes)
+                        p_fields = Lookup.process_fields(
+                            fields=fields,
+                            key_index=key_index,
+                            escape_quotes=self.escape_quotes)
                         self.send_data(row=p_fields)
 
                         # Send full log for historic

--- a/devo/sender/lookup.py
+++ b/devo/sender/lookup.py
@@ -44,7 +44,7 @@ class Lookup:
     CONTROL_TABLE = "my.lookup.control"
 
     def __init__(self, name="example", historic_tag=None,
-                 con=None, delay=5):
+                 con=None, delay=5, escape_quotes=False):
 
         if not re.match(r"^[A-Za-z0-9_]+$", name):
             raise Exception('Devo Lookup: The name of the lookup is incorrect,'
@@ -59,6 +59,7 @@ class Lookup:
         self.historic_tag = historic_tag
         self.name = name.replace(" ", "_")
         self.delay = delay
+        self.escape_quotes = escape_quotes
 
     # Helper methods
     # --------------------------------------------------------------------------
@@ -82,7 +83,7 @@ class Lookup:
         self.send_control(event=event, headers=p_headers, action=action)
 
     def send_data_line(self, key=None, fields=None,
-                       delete=False, key_index=None, escape_quotes=False):
+                       delete=False, key_index=None):
         """
         Send only the data
         :param key: key value, optional if you send 'key_index'
@@ -93,7 +94,7 @@ class Lookup:
         :return:
         """
         # TODO: Deprecate this if with list_to_fields in v4
-        p_fields = Lookup.list_to_fields(fields=fields, key=key, escape_quotes=escape_quotes) \
+        p_fields = Lookup.list_to_fields(fields=fields, key=key, escape_quotes=self.escape_quotes) \
             if key_index is None \
             else Lookup.process_fields(fields=fields, key_index=key_index)
         self.send_data(row=p_fields, delete=delete)
@@ -208,7 +209,7 @@ class Lookup:
                     for fields in spam_reader:
                         field_action = fields.pop(delete_index)
                         p_fields = Lookup.process_fields(fields=fields,
-                                                         key_index=key_index)
+                                                         key_index=key_index, escape_quotes=self.escape_quotes)
                         self.send_data(row=p_fields,
                                        delete=field_action == "delete"
                                        or field_action == "DELETE")
@@ -220,7 +221,7 @@ class Lookup:
                 else:
                     for fields in spam_reader:
                         p_fields = Lookup.process_fields(fields=fields,
-                                                         key_index=key_index)
+                                                         key_index=key_index, escape_quotes=self.escape_quotes)
                         self.send_data(row=p_fields)
 
                         # Send full log for historic
@@ -369,7 +370,7 @@ class Lookup:
         :return:
         """
         # First the key
-        out = '%s' % Lookup.clean_field(fields[key_index])
+        out = '%s' % Lookup.clean_field(fields[key_index], escape_quotes)
 
         # The rest of the fields
         for item in fields[:key_index] + fields[key_index + 1:]:
@@ -385,7 +386,7 @@ class Lookup:
         :param str key: key name, optional
         :result str
         """
-        key = Lookup.clean_field(key)
+        key = Lookup.clean_field(key, escape_quotes)
         # First the key
         out = '%s' % key
 

--- a/devo/sender/lookup.py
+++ b/devo/sender/lookup.py
@@ -94,9 +94,11 @@ class Lookup:
         :return:
         """
         # TODO: Deprecate this if with list_to_fields in v4
-        p_fields = Lookup.list_to_fields(fields=fields, key=key, escape_quotes=self.escape_quotes) \
+        p_fields = Lookup.list_to_fields(fields=fields, key=key,
+                                         escape_quotes=self.escape_quotes) \
             if key_index is None \
-            else Lookup.process_fields(fields=fields, key_index=key_index)
+            else Lookup.process_fields(fields=fields, key_index=key_index,
+                                       escape_quotes=self.escape_quotes)
         self.send_data(row=p_fields, delete=delete)
 
     @staticmethod
@@ -209,7 +211,8 @@ class Lookup:
                     for fields in spam_reader:
                         field_action = fields.pop(delete_index)
                         p_fields = Lookup.process_fields(fields=fields,
-                                                         key_index=key_index, escape_quotes=self.escape_quotes)
+                                                         key_index=key_index,
+                                                         escape_quotes=self.escape_quotes)
                         self.send_data(row=p_fields,
                                        delete=field_action == "delete"
                                        or field_action == "DELETE")
@@ -221,7 +224,8 @@ class Lookup:
                 else:
                     for fields in spam_reader:
                         p_fields = Lookup.process_fields(fields=fields,
-                                                         key_index=key_index, escape_quotes=self.escape_quotes)
+                                                         key_index=key_index,
+                                                         escape_quotes=self.escape_quotes)
                         self.send_data(row=p_fields)
 
                         # Send full log for historic

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -18,7 +18,8 @@ object into the _lookup_ variable with the new parameters or add in the CLI flag
 Example:
 
 ```
-{   sender": {
+{   
+    sender": {
         ...
     },
     "lookup": {
@@ -228,28 +229,21 @@ You can use config file to send types list:
 ```
 ##### Double quotes in the field value
 
-Any double quotes inside the field value can cause trouble when sending the lookup if not escaped 
-and example of this can be seen below:
+Any double quotes inside the field value can cause trouble when sending the lookup if this is not escaped.
+An example of this case can be seen below:
 
 `lookup.send_data_line(key="11", fields=["11", 'double quotes must escaped"'])`
 
-That lookup will fail to be sent, to avoid this, add `"escape_quotes": true` to the lookup config
-file and `escape_quotes=True` to the constructor, below both examples are shown:
+That lookup creation will fail because that double quote will be interpreted as a field termination and 
+the number of fields for that row will unmatch the corresponding number of columns. To avoid this, 
+add `"escape_quotes": true` to the lookup configuration file and `escape_quotes=True` to the `Lookup` constructor. 
+Below, an example for the constructor is shown:
 
 ```
-{   sender": {
-        ...
-    },
-    "lookup": {
-        "name": "Test_Lookup_of_180306_02",
-        "file": "test_lookup.csv",
-        "lkey": "KEY"
-        "escape_quotes": true
-    }
-}
-```
-
 `lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con, escape_quotes=True)`
+```
+
+To see an example for the lookup configuration please refer to the one shown at the start of the document.
 
 This will escape ALL double quotes in the field value by adding a second double quote to it.
 

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -25,6 +25,7 @@ Example:
         "name": "Test_Lookup_of_180306_02",
         "file": "test_lookup.csv",
         "lkey": "KEY"
+        "escape_quotes": true
     }
 }
 ```
@@ -225,3 +226,31 @@ You can use config file to send types list:
     ....
  }}
 ```
+##### Double quotes in the field value
+
+Any double quotes inside the field value can cause trouble when sending the lookup if not escaped 
+and example of this can be seen below:
+
+`lookup.send_data_line(key="11", fields=["11", 'double quotes must escaped"'])`
+
+That lookup will fail to be sent, to avoid this, add `"escape_quotes": true` to the lookup config
+file and `escape_quotes=True` to the constructor, below both examples are shown:
+
+```
+{   sender": {
+        ...
+    },
+    "lookup": {
+        "name": "Test_Lookup_of_180306_02",
+        "file": "test_lookup.csv",
+        "lkey": "KEY"
+        "escape_quotes": true
+    }
+}
+```
+
+`lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con, escape_quotes=True)`
+
+This will escape ALL double quotes in the field value by adding a second double quote to it.
+
+The default behavior is to NOT escape any double quotes. 

--- a/tests/sender/send_lookup.py
+++ b/tests/sender/send_lookup.py
@@ -243,64 +243,25 @@ class TestLookup(unittest.TestCase):
         self.assertEqual(fields, ["a", "b", "c"])
         self.assertEqual(processed_fields, '"b","a","c"')
 
-    # Standard behavior for clean_field
-    def test_clean_field_standard(self):
-        engine_config = SenderConfigSSL(
-            address=(self.server, self.port),
-            key=self.key,
-            cert=self.cert,
-        )
-        con = Sender(engine_config)
-
-        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
-        result = lookup.clean_field("No double quotes", False)
-
-        self.assertEqual(result, '"No double quotes"')
-
-    # Standard behavior is expected since no double quotes are present
-    def test_clean_field_no_quotes(self):
-        engine_config = SenderConfigSSL(
-            address=(self.server, self.port),
-            key=self.key,
-            cert=self.cert,
-        )
-        con = Sender(engine_config)
-
-        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
-        result = lookup.clean_field("No double quotes", True)
-
-        self.assertEqual(result, '"No double quotes"')
-
-    # Double quotes are present but they will not be escaped
-    def test_clean_field_double_quotes(self):
-        engine_config = SenderConfigSSL(
-            address=(self.server, self.port),
-            key=self.key,
-            cert=self.cert,
-        )
-        con = Sender(engine_config)
-
-        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
-        result = lookup.clean_field('Double quotes"', False)
-
-        self.assertEqual(result, '"Double quotes""')
-
-    # Double quotes are present ane they will be escaped
-    def test_clean_field_escape_quotes(self):
-        engine_config = SenderConfigSSL(
-            address=(self.server, self.port),
-            key=self.key,
-            cert=self.cert,
-        )
-        con = Sender(engine_config)
-
-        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
-        result = lookup.clean_field('Double quotes"', True)
-
-        self.assertEqual(result, '"Double quotes"""')
+    # Clean field
+    def test_clean_field_parametrized(self):
+        test_params = [
+            ("No double quotes", False, '"No double quotes"'),
+            ("No double quotes", True, '"No double quotes"'),
+            ('Double quotes"', False, '"Double quotes""'),
+            ('Double quotes"', True, '"Double quotes"""')
+        ]
+        for field, escape_quotes, expected_result in test_params:
+            with self.subTest(
+                field=field,
+                escape_quotes=escape_quotes,
+                expected_result=expected_result
+            ):
+                result = Lookup.clean_field(field, escape_quotes)
+                self.assertEqual(result, expected_result)
 
     # Test to make sure escape_quotes is propagated correctly
-    def test_escape_quotes_in_constructor(self):
+    def test_escape_quotes_in_send_data_line_key(self):
         engine_config = SenderConfigSSL(
             address=(self.server, self.port),
             key=self.key,
@@ -316,33 +277,62 @@ class TestLookup(unittest.TestCase):
             lookup.send_data_line(key="11", fields=["11", 'Double quotes"'])
             clean_field.assert_called_with('Double quotes"', True)
 
-        with mock.patch.object(Lookup, 'clean_field',
-                               wraps=Lookup.clean_field) as constructor:
-            lookup.send_data_line(fields=["11", 'Double quotes"'])
-            constructor.assert_called_with('Double quotes"', True)
-
-        with open(self.lookup_file) as f:
-            line = f.readline()
-
-        lookup.send_csv(
-            self.lookup_file,
-            headers=line.rstrip().split(","),
-            key=self.lookup_key,
+    # Test to make sure escape_quotes is propagated correctly
+    def test_escape_quotes_in_send_data_line(self):
+        engine_config = SenderConfigSSL(
+            address=(self.server, self.port),
+            key=self.key,
+            cert=self.cert,
         )
+        con = Sender(engine_config)
+
+        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con,
+                        escape_quotes=True)
 
         with mock.patch.object(Lookup, 'clean_field',
-                               wraps=Lookup.clean_field) as constructor:
+                               wraps=Lookup.clean_field) as clean_field:
+            lookup.send_data_line(fields=["11", 'Double quotes"'])
+            clean_field.assert_called_with('Double quotes"', True)
+
+            # Test to make sure escape_quotes is propagated correctly
+
+    def test_escape_quotes_in_send_csv(self):
+        engine_config = SenderConfigSSL(
+            address=(self.server, self.port),
+            key=self.key,
+            cert=self.cert,
+        )
+        con = Sender(engine_config)
+
+        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con,
+                        escape_quotes=True)
+
+        with mock.patch.object(Lookup, 'clean_field',
+                               wraps=Lookup.clean_field) as clean_field:
             lookup.send_csv(path=self.lookup_file,
-                            headers=line.rstrip().split(","),
+                            has_header=True,
                             key=self.lookup_key)
-            constructor.assert_called_with('ffffff', True)
+            clean_field.assert_called_with('ffffff', True)
+
+            # Test to make sure escape_quotes is propagated correctly
+
+    def test_escape_quotes_in_send_csv_delete_index(self):
+        engine_config = SenderConfigSSL(
+            address=(self.server, self.port),
+            key=self.key,
+            cert=self.cert,
+        )
+        con = Sender(engine_config)
+
+        lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con,
+                        escape_quotes=True)
 
         with mock.patch.object(Lookup, 'clean_field',
-                               wraps=Lookup.clean_field) as constructor:
+                               wraps=Lookup.clean_field) as clean_field:
             lookup.send_csv(path=self.lookup_file,
-                            headers=line.rstrip().split(","),
+                            has_header=True,
                             key=self.lookup_key, delete_field="Green")
-            constructor.assert_called_with('ffffff', True)
+            clean_field.assert_called_with('ffffff', True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
New parameter `escape_quotes` added to `send_data_line` to allow the user to specify if he wants any double quote in the data line to be escaped.

Example input:

`lookup.send_data_line(key="11", fields=["11", '""double quote: 3"'], escape_quotes=True)`

Example output:

![Output](https://user-images.githubusercontent.com/96867743/147818752-9724696b-5796-42e0-8db2-0df8b9c88358.png)

Closes #106 

