### PR TITLE
Research/nonblocking socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.2.0] - Unreleased
+## [5.1.2-rc1] - 2023-03-17
 ### Added
- * Closing handshake protocol improved in Sender
- * NonBlocking Socket support added
+ * Sender: NonBlocking Socket support added
  * `responses` dependency open from ==0.22.0 to >=0.22.0
 ### Fixed
- * Download EOF channel TCP FIN detected and connection restarted
+ * Sender: Closing handshake protocol improved to avoid losing of events. Upstream channel is closed and then client waits for the closing of downstream channel 
+ * Sender: Monitoring of the EOF signal in downstream channel to detect whether server endpoint have closed the session
  * Fix message file management in CLI
 
 ## [5.1.1] - 2023-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+ * NonBlocking Socket support added
+### Fixed
+ * Download EOF channel TCP FIN detected and connection restarted
+ * Fix message file management in CLI
+
 ## [5.1.2] - Unreleased
 ### Added
  * `responses` dependency open from ==0.22.0 to >=0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ in `devo/sender/data.py`
 ### Fixed
  * Ingestion endpoint has an inactivity timeout that when reached closes the connection. `devo-sdk` is aware of such a timeout and restart connection before is reached. New parameter `inactivity_timeout` in class `Sender` to set up it. Its default value is 30 seconds.
  * Syntax error when calling `Path.is_file()`
- * Documentation related to parameter `key` removal at `devo.sender.lookup.Lookup.send_data_line` in version 5.0.0 
+ * Documentation related to parameter `key` removal at `devo.sender.lookup.Lookup.send_data_line` in version 5.0.0
 
 ## [5.0.2] - 2023-01-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [5.2.0] - Unreleased
 ### Added
+ * Closing handshake protocol improved in Sender
  * NonBlocking Socket support added
+ * `responses` dependency open from ==0.22.0 to >=0.22.0
 ### Fixed
  * Download EOF channel TCP FIN detected and connection restarted
  * Fix message file management in CLI
-
-## [5.1.2] - Unreleased
-### Added
- * `responses` dependency open from ==0.22.0 to >=0.22.0
 
 ## [5.1.1] - 2023-03-09
 ### Added

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = 'Devo Python Library.'
 __url__ = 'http://www.devo.com'
-__version__ = "5.1.2"
+__version__ = "5.1.2-rc1"
 __author__ = 'Devo'
 __author_email__ = 'support@devo.com'
 __license__ = 'MIT'

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -586,7 +586,7 @@ class Sender(logging.Handler):
                 # errno.EAGAIN means nothing to get, but socket working
                 pass
         except ssl.SSLWantReadError:
-            # If the SSL socket not ready yet, select may throw an exception
+            # If the socket has data but SSL wrapper not ready yet, select may throw an exception
             pass
 
         return True
@@ -923,3 +923,5 @@ def open_file(file, mode='r', encoding='utf-8'):
                     encoding=encoding if not mode.endswith('b') else None)
     else:
         raise DevoSenderException(ERROR_MSGS.WRONG_FILE_TYPE % str(type(file)))
+
+

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -3,6 +3,7 @@
 and sending of data to Devo """
 import errno
 import logging
+import select
 import socket
 import ssl
 import sys
@@ -392,6 +393,7 @@ class Sender(logging.Handler):
                 ERROR_MSGS.TCP_CONN_ESTABLISHMENT_SOCKET % str(error)) from error
 
         self.timestart = int(round(time.time() * 1000))
+        self.socket.setblocking(False)
 
     def __connect_ssl(self):
         """
@@ -453,6 +455,7 @@ class Sender(logging.Handler):
                                   % (repr(self.socket.getpeername()),
                                      str(self.reconnection)))
             self.timestart = int(round(time.time() * 1000))
+            self.socket.setblocking(False)
 
         except socket.error as error:
             self.close()
@@ -558,6 +561,34 @@ class Sender(logging.Handler):
             self.close()
             return False
 
+        # If the channel was closed by the other endpoint, ingestion balancer,
+        # the reading of the download channel will return EOF. This is
+        # checked by reading a ready buffer but getting no data, empty bytes
+        try:
+            # Is the channel ready for reading?
+            select_result = select.select([self.socket], [], [], 0)
+            if select_result[0]:
+                # Read it
+                buf = self.socket.recv(1)
+                # If no data, EOF and channel is closed
+                if buf == b'':
+                    # Restart connection
+                    self.close()
+                    return False
+        except BlockingIOError as exc:
+            if exc.errno == errno.ECONNRESET:
+                # A TCP RST implies error in channel
+                raise IOError("Connection reset by endpoint") from exc
+            elif exc.errno not in [errno.EAGAIN, errno.EWOULDBLOCK]:
+                # Any other error but EAGAIN and EWOULDBLOCK here
+                raise IOError("Error while accessing socket") from exc
+            else:
+                # errno.EAGAIN means nothing to get, but socket working
+                pass
+        except ssl.SSLWantReadError:
+            # If the SSL socket not ready yet, select may throw an exception
+            pass
+
         return True
 
     def close(self):
@@ -600,9 +631,16 @@ class Sender(logging.Handler):
         for iteration in range(0, total):
             part = record[int(iteration * 4096):
                           int((iteration + 1) * 4096)]
+            select_result = select.select([], [self.socket], [],
+                                          self.socket_timeout)
+            if select_result[1]:
+                if self.socket.sendall(part) is not None:
+                    raise DevoSenderException(str(ERROR_MSGS.SEND_ERROR))
+                sent += len(part)
+            else:
+                raise DevoSenderException(
+                    ERROR_MSGS.ERROR_AFTER_TIMEOUT)
             self.last_message = int(time.time())
-            if self.socket.sendall(part) is not None:
-                raise DevoSenderException(ERROR_MSGS.SEND_ERROR)
             sent += len(part)
         if sent == 0:
             raise DevoSenderException(ERROR_MSGS.SEND_ERROR)
@@ -625,9 +663,17 @@ class Sender(logging.Handler):
                     if not multiline and not zip:
                         msg = self.__encode_record(record)
                         sent = len(msg)
+                        select_result = select.select([], [self.socket], [],
+                                                      self.socket_timeout)
+                        if select_result[1]:
+                            if self.socket.sendall(msg) is not None:
+                                raise DevoSenderException(
+                                    str(ERROR_MSGS.SEND_ERROR))
+                            return 1
+                        else:
+                            raise DevoSenderException(
+                                str(ERROR_MSGS.ERROR_AFTER_TIMEOUT))
                         self.last_message = int(time.time())
-                        if self.socket.sendall(msg) is not None:
-                            raise DevoSenderException(ERROR_MSGS.SEND_ERROR)
                         return 1
                     if multiline:
                         record = self.__encode_multiline(record)

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -581,10 +581,11 @@ class Sender(logging.Handler):
             try:
                 self.socket.shutdown(SHUT_WR)
                 self.__wait_for_EOF()
-            except Exception as exc:  # Try else continue
+            except Exception:  # Try else continue
                 logging.exception(ERROR_MSGS.CLOSING_ERROR)
-            self.socket.close()
-            self.socket = None
+            finally:
+                self.socket.close()
+                self.socket = None
 
     @staticmethod
     def __encode_multiline(record):

--- a/devo/sender/scripts/sender_cli.py
+++ b/devo/sender/scripts/sender_cli.py
@@ -101,7 +101,7 @@ def data(**kwargs):
                                 % Path(config['file']).absolute()))
                 return
             if config['multiline']:
-                with config['file'].open(mode='r') as file:
+                with open(config['file'], mode='r') as file:
                     content = file.read()
                     if not config['raw']:
                         sended += con.send(tag=config['tag'], msg=content,
@@ -112,7 +112,7 @@ def data(**kwargs):
                                                multiline=config['multiline'],
                                                zip=config.get("zip", False))
             else:
-                with config['file'].open(mode='r') as file:
+                with open(config['file'], mode='r') as file:
                     if config['header']:
                         next(file)
                     for line in file:

--- a/tests/sender/cli.py
+++ b/tests/sender/cli.py
@@ -20,7 +20,7 @@ class TestSender(unittest.TestCase):
         self.tcp_port = int(os.getenv('DEVO_SENDER_TCP_PORT', 4489))
 
         self.remote_address = os.getenv('DEVO_REMOTE_SENDER_SERVER',
-                                 "collector-us.devo.io")
+                                        "collector-us.devo.io")
         self.remote_port = int(os.getenv('DEVO_REMOTE_SENDER_PORT', 443))
 
         self.key = os.getenv('DEVO_SENDER_KEY', CLIENT_KEY)
@@ -54,7 +54,7 @@ class TestSender(unittest.TestCase):
         self.config_path = "/tmp/devo_sender_tests_config.json"
         configuration.save(path=self.config_path)
 
-        self.bad_json_config_path ="./common/bad_json_config.json"
+        self.bad_json_config_path = "./common/bad_json_config.json"
         self.bad_yaml_config_path = "./common/bad_yaml_config.yaml"
 
     def test_cli_args(self):
@@ -150,6 +150,23 @@ class TestSender(unittest.TestCase):
         self.assertIsNone(result.exception)
         self.assertGreater(int(result.output.split("Sended: ")[-1]), 0)
 
+    def test_cli_normal_send_multiline_with_certificates_checking(self):
+        runner = CliRunner()
+        result = runner.invoke(data, ["--debug",
+                                      "--address", self.remote_address,
+                                      "--port", self.remote_port,
+                                      "--key", self.key,
+                                      "--cert", self.cert,
+                                      "--chain", self.chain,
+                                      "--tag", self.my_app,
+                                      "--verify_mode", 0,
+                                      '--check_hostname', False,
+                                      "--multiline",
+                                      "--file", self.test_file])
+
+        self.assertIsNone(result.exception)
+        self.assertGreater(int(result.output.split("Sended: ")[-1]), 0)
+
     def test_cli_with_config_file(self):
         if self.config_path:
             runner = CliRunner()
@@ -222,6 +239,7 @@ class TestSender(unittest.TestCase):
 
         self.assertIsNotNone(result.exception)
         self.assertEquals(result.exit_code, 64)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sender/send_data.py
+++ b/tests/sender/send_data.py
@@ -78,7 +78,7 @@ class TestSender(unittest.TestCase):
 
     @staticmethod
     def read(con, length: int):
-        if not select.select([con.socket], [], [], con.socket_timeout):
+        if not select.select([con.socket], [], [], con.socket_timeout)[0]:
             raise Exception("Timeout reached during read operation")
         if isinstance(con.socket, SSLSocket):
             while True:

--- a/tests/sender/send_data.py
+++ b/tests/sender/send_data.py
@@ -79,7 +79,7 @@ class TestSender(unittest.TestCase):
     @staticmethod
     def read(con, length: int):
         if not select.select([con.socket], [], [], con.socket_timeout)[0]:
-            raise Exception("Timeout reached during read operation")
+            raise TimeoutError("Timeout reached during read operation")
         if isinstance(con.socket, SSLSocket):
             while True:
                 try:

--- a/tests/sender/send_lookup.py
+++ b/tests/sender/send_lookup.py
@@ -34,7 +34,7 @@ class TestLookup(unittest.TestCase):
     @staticmethod
     def read(con, length: int):
         if not select.select([con.socket], [], [], con.socket_timeout)[0]:
-            raise Exception("Timeout reached during read operation")
+            raise TimeoutError("Timeout reached during read operation")
         return con.socket.recv(length)
 
     def test_ssl_lookup_csv_send(self):

--- a/tests/sender/send_lookup.py
+++ b/tests/sender/send_lookup.py
@@ -33,7 +33,7 @@ class TestLookup(unittest.TestCase):
 
     @staticmethod
     def read(con, length: int):
-        if not select.select([con.socket], [], [], con.socket_timeout):
+        if not select.select([con.socket], [], [], con.socket_timeout)[0]:
             raise Exception("Timeout reached during read operation")
         return con.socket.recv(length)
 

--- a/tests/sender/send_lookup.py
+++ b/tests/sender/send_lookup.py
@@ -1,4 +1,5 @@
 import re
+import select
 import unittest
 from ssl import CERT_NONE
 from unittest import mock
@@ -29,6 +30,12 @@ class TestLookup(unittest.TestCase):
         )
 
         self.lookup_key = "KEY"
+
+    @staticmethod
+    def read(con, length: int):
+        if not select.select([con.socket], [], [], con.socket_timeout):
+            raise Exception("Timeout reached during read operation")
+        return con.socket.recv(length)
 
     def test_ssl_lookup_csv_send(self):
 
@@ -70,16 +77,18 @@ class TestLookup(unittest.TestCase):
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
         p_headers = Lookup.list_to_headers(["KEY", "HEX", "COLOR"], "KEY")
         lookup.send_control("START", p_headers, "INC")
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_data_line(key_index=0, fields=["11", "HEX12", "COLOR12"])
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_control("END", p_headers, "INC")
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
 
         con.socket.shutdown(0)
+
+
 
     def test_create_lookup_key_index_preserves_structure(self):
         engine_config = SenderConfigSSL(
@@ -156,19 +165,17 @@ class TestLookup(unittest.TestCase):
             verify_mode=CERT_NONE,
         )
         con = Sender(engine_config)
-
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
         p_headers = Lookup.list_to_headers(["KEY", "HEX", "COLOR"], "KEY")
         lookup.send_control("START", p_headers, "FULL")
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_data_line(key_index=0, fields=["11", "HEX12", "COLOR12"])
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_control("END", p_headers, "FULL")
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
-
         con.socket.shutdown(0)
 
     # delete a line from lookup
@@ -186,15 +193,15 @@ class TestLookup(unittest.TestCase):
         lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con)
         p_headers = Lookup.list_to_headers(["KEY", "HEX", "COLOR"], "KEY")
         lookup.send_control("START", p_headers, "INC")
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_data_line(
             key_index=0, fields=["11", "HEX12", "COLOR12"], delete=True
         )
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_control("END", p_headers, "INC")
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
 
         con.socket.shutdown(0)
@@ -214,15 +221,15 @@ class TestLookup(unittest.TestCase):
         lookup.send_headers(
             headers=["KEY", "HEX", "COLOR"], key="KEY", action="START"
         )
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_data_line(key_index=0, fields=["11", "HEX12", "COLOR12"])
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
         lookup.send_headers(
             headers=["KEY", "HEX", "COLOR"], key="KEY", action="END"
         )
-        if len(con.socket.recv(1000)) == 0:
+        if len(TestLookup.read(con, 1000)) == 0:
             raise Exception("Not msg sent!")
 
         con.socket.shutdown(0)


### PR DESCRIPTION
## [5.1.2-rc1] - 2023-03-17
### Added
 * Sender: NonBlocking Socket support added
 * `responses` dependency open from ==0.22.0 to >=0.22.0
### Fixed
 * Sender: Closing handshake protocol improved to avoid losing of events. Upstream channel is closed and then client waits for the closing of downstream channel 
 * Sender: Monitoring of the EOF signal in downstream channel to detect whether server endpoint have closed the session
 * Fix message file management in CLI