### PR TITLE
Improvements for gzip sending

### DIFF
--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -87,7 +87,7 @@ class DevoSenderException(Exception):
         :param message: Message describing the exception. It will be also
          used as `args` attribute in `Exception` class
         """
-        if isinstance(message, str) is False:
+        if not isinstance(message, str):
             raise TypeError(f'must be str, not {type(message).__name__}')
         self.message: str = message
         """Message describing exception"""
@@ -349,9 +349,9 @@ class SenderBufferFlusher(Thread):
 
         # "buffer_timeout" and "flush_buffer_func" must have valid values
         if not self.buffer_timeout or self.buffer_timeout <= 0.0:
-            raise Exception(f'"buffer_timeout" is required and must have a value grater than 0.0')
+            raise DevoSenderException('"buffer_timeout" is required and must have a value grater than 0.0')
         if not self.flush_buffer_func:
-            raise Exception(f'"flush_buffer_func" is required')
+            raise DevoSenderException('"flush_buffer_func" is required')
         super().start()
 
     def run(self):

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -1061,18 +1061,29 @@ class Sender(logging.Handler):
                     self.buffer.events = 0
             return 0
 
-    def get_buffer(self) -> dict:
+    def get_buffer_info(self) -> dict:
         """
-        Getter mewthod for the buffer.
+        Getter method for the buffer.
         Useful for emergency situations when we can't send
         :return: dict with "events" and "text_buffer" values
         """
         with self.buffer_lock:
-            if self.buffer.text_buffer:
-                return {
-                    "events": self.buffer.events,
-                    "text_buffer": self.buffer.text_buffer,
-                }
+            return {
+                "events": self.buffer.events,
+                "text_buffer": self.buffer.text_buffer,
+            }
+
+    def set_buffer_info(self, text_buffer: bytes, num_events: int) -> None:
+        """
+        Setter method for the buffer.
+        Useful for emergency situations when we can't send
+        :param: text_buffer (bytes)
+        :param: num_events (int)
+        :return:
+        """
+        with self.buffer_lock:
+            self.buffer.text_buffer = text_buffer
+            self.buffer.events = num_events
 
     @staticmethod
     def for_logging(config=None, con_type=None, tag=None, level=None):


### PR DESCRIPTION
These changes add a thread (SenderBufferFlusher) for controlling the flushing of the buffer used when sending using Gzip.
The SenderBuffer class has been modified a bit but these changes don't affect the current functionality.

The usage of this SenderBufferFlusher thread is optional and by default, it will not be used.
