### PR TITLE
fix: Upgraded dependency cryptography~=43.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.4.1] - 2024-09-13
+
+### Security
+- `cryptography` dependency upgraded from `cryptography~=42.0.5` to `cryptography~=43.0.1`
+
 ## [5.4.0] - 2024-07-09
 
 ### Changed

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = "Devo Python Library."
 __url__ = "http://www.devo.com"
-__version__ = "5.4.0"
+__version__ = "5.4.1"
 __author__ = "Devo"
 __author_email__ = "support@devo.com"
 __license__ = "MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pem~=21.2.0
 pyopenssl~=24.1.0
 pytz~=2024.1
 certifi~=2024.7.4
-cryptography~=42.0.8
+cryptography~=43.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==8.1.7
 PyYAML==6.0.1
 requests~=2.32
 pem~=21.2.0
-pyopenssl~=24.1.0
+pyopenssl~=24.2.1
 pytz~=2024.1
 certifi~=2024.7.4
 cryptography~=43.0.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRES = [
     "pyopenssl~=24.1.0",
     "pytz~=2024.1",
     "certifi~=2024.7.4",
-    "cryptography~=42.0.8",
+    "cryptography~=43.0.1",
 ]
 EXTRAS_REQUIRE = {
     "dev": [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     "click==8.1.7",
     "PyYAML==6.0.1",
     "pem~=21.2.0",
-    "pyopenssl~=24.1.0",
+    "pyopenssl~=24.2.1",
     "pytz~=2024.1",
     "certifi~=2024.7.4",
     "cryptography~=43.0.1",


### PR DESCRIPTION
After vulnerability https://github.com/DevoInc/python-sdk/security/code-scanning/34 found t was requested to be corrected https://devoinc.atlassian.net/browse/AL-1167

This dependency requires also to upgrade pyopenssl to 24.2.1