### PR TITLE
Fix[AWS Jobs]: Fixed destination jobs in AWS/Serrea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.4.2] - 2024-10-02
+
+### Fixed
+- `destination` parameter its not working, forcing NO_KEEPALIVE_TOKEN to avoid problems in client jobs creation
+- 
 ## [5.4.1] - 2024-09-13
 
 ### Security

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = "Devo Python Library."
 __url__ = "http://www.devo.com"
-__version__ = "5.4.1"
+__version__ = "5.4.2"
 __author__ = "Devo"
 __author_email__ = "support@devo.com"
 __license__ = "MIT"

--- a/devo/api/client.py
+++ b/devo/api/client.py
@@ -173,6 +173,7 @@ class ClientConfig:
         self.processor = None
         self.set_processor(processor)
         self.keepAliveToken = None
+
         self.set_keepalive_token(keepAliveToken)
 
         if pragmas:
@@ -235,7 +236,9 @@ class ClientConfig:
         # keepalive (cannot be modified), but implementation uses
         # NO_KEEP_ALIVE value as it does not change the query msgpack and
         # xls does not support keepalive
-        if self.response in [
+        if self.destination is not None:
+            self.keepAliveToken = NO_KEEPALIVE_TOKEN
+        elif self.response in [
             "json",
             "json/compact",
             "json/simple",
@@ -253,7 +256,6 @@ class ClientConfig:
                 logging.warning(ERROR_MSGS["keepalive_not_supported"])
             self.keepAliveToken = NO_KEEPALIVE_TOKEN
         return True
-
 
 class Client:
     """


### PR DESCRIPTION

## [5.4.2] - 2024-10-02

### Fixed
- `destination` parameter its not working, forcing NO_KEEPALIVE_TOKEN to avoid problems in client jobs creation
- 