### PR TITLE
feat: logging to "devo.data" instead of "root"

### DIFF
--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -28,6 +28,8 @@ from .transformsyslog import (COMPOSE, COMPOSE_BYTES, FACILITY_USER, FORMAT_MY,
 
 PYPY = hasattr(sys, "pypy_version_info")
 
+log = logging.getLogger(__name__)
+
 
 class ERROR_MSGS(str, Enum):
 
@@ -764,7 +766,7 @@ class Sender(logging.Handler):
                 self.socket.shutdown(SHUT_WR)
                 self.__wait_for_EOF()
             except Exception:  # Try else continue
-                logging.warning(ERROR_MSGS.CLOSING_ERROR)
+                log.warning(ERROR_MSGS.CLOSING_ERROR)
             finally:
                 self.socket.close()
                 self.socket = None


### PR DESCRIPTION
Before this change, the method `close()` from `devo//sender/data.py` was generating the log trace to the `root` logger instead of the expected one (the class logger).