### PR TITLE
Data logging

### DIFF
--- a/.github/workflows/python-pull-request.yml
+++ b/.github/workflows/python-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        version: [ "3.12", "3.11", "3.10", "3.9" ]
+        version: [ "3.13", "3.12", "3.11", "3.10", "3.9" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.1] - 2025-02-05
+
+### Added
+ - Added Python 3.13 support 
+
+### Changed
+ - Change logger name in `common/sender/data.py` so it logs to `devo.data` instead to ROOT
+
+### Fixed
+ - Bump security libraries to updated versions
+ - `test_api_cli` corrected as error code changed nomenclature
+
+
 ## [6.0.0] - 2024-10-07
 
 ### Changed

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = "Devo Python Library."
 __url__ = "http://www.devo.com"
-__version__ = "6.0.0"
+__version__ = "6.0.1"
 __author__ = "Devo"
 __author_email__ = "support@devo.com"
 __license__ = "MIT"

--- a/devo/sender/data.py
+++ b/devo/sender/data.py
@@ -28,6 +28,8 @@ from .transformsyslog import (COMPOSE, COMPOSE_BYTES, FACILITY_USER, FORMAT_MY,
 
 PYPY = hasattr(sys, "pypy_version_info")
 
+log = logging.getLogger(__name__)
+
 
 class ERROR_MSGS(str, Enum):
 
@@ -764,7 +766,7 @@ class Sender(logging.Handler):
                 self.socket.shutdown(SHUT_WR)
                 self.__wait_for_EOF()
             except Exception:  # Try else continue
-                logging.warning(ERROR_MSGS.CLOSING_ERROR)
+                log.warning(ERROR_MSGS.CLOSING_ERROR)
             finally:
                 self.socket.close()
                 self.socket = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-click==8.1.7
+click==8.1.8
 PyYAML~=6.0.1
 requests~=2.32
 pem~=21.2.0
-pyopenssl~=24.2.1
+pyopenssl~=25.0.0
 pytz~=2024.1
-certifi~=2024.7.4
-cryptography~=43.0.1
+certifi~=2025.1.31
+cryptography~=44.0.0

--- a/setup.py
+++ b/setup.py
@@ -22,19 +22,20 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 INSTALL_REQUIRES = [
     "requests~=2.32",
-    "click==8.1.7",
+    "click==8.1.8",
     "PyYAML~=6.0.1",
     "pem~=21.2.0",
-    "pyopenssl~=24.2.1",
+    "pyopenssl~=25.0.0",
     "pytz~=2024.1",
-    "certifi~=2024.7.4",
-    "cryptography~=43.0.1",
+    "certifi~=2025.1.31",
+    "cryptography~=44.0.0",
 ]
 EXTRAS_REQUIRE = {
     "dev": [

--- a/tests/integration/test_api_cli.py
+++ b/tests/integration/test_api_cli.py
@@ -201,7 +201,7 @@ def test_bad_credentials(api_config):
         ],
     )
     assert isinstance(result.exception, DevoClientException)
-    assert result.exception.code == 12
+    assert result.exception.code in [5, 12]
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
## [6.0.1] - 2025-02-05

### Added
 - Added Python 3.13 support 

### Changed
 - Change logger name in `common/sender/data.py` so it logs to `devo.data` instead to ROOT

### Fixed
 - Bump security libraries to updated versions
 - `test_api_cli` corrected as error code changed nomenclature