### PR TITLE
Add escape new line option for lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.2] - 2025-03-07
+
+### Added
+ - Added new --escapenewline or -enl option in lookup creation, edition and deletion. It will escape with
+double backslash any new line char found inside a csv field.
+
 ## [6.0.1] - 2025-02-05
 
 ### Added

--- a/devo/sender/scripts/sender_cli.py
+++ b/devo/sender/scripts/sender_cli.py
@@ -255,6 +255,13 @@ def data(**kwargs):
     default=False,
 )
 @click.option(
+    "--escapenewline",
+    "-enl",
+    is_flag=True,
+    help="Escape New Line char. Default: False",
+    default=False,
+)
+@click.option(
     "--no-verify-certificates",
     help="Do not Verify certificates credentials before connection",
     type=bool,
@@ -279,6 +286,7 @@ def lookup(**kwargs):
         historic_tag=None,
         con=con,
         escape_quotes=config["escapequotes"],
+        escape_newline=config["escapenewline"]
     )
 
     if lookup.check_quotes(config["file"]):

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -257,3 +257,24 @@ To see an example for the lookup configuration please refer to the one shown at 
 This will escape ALL double quotes in the field value by adding a second double quote to it.
 
 The default behavior is to NOT escape any double quotes.
+
+#### New line chars in the field value
+
+Any new line char inside the field value can cause trouble when creating the lookup if this is not escaped.
+An example of this case can be seen below:
+
+```python
+lookup.send_data_line(key_index=0, fields=["11", 'new lines\n must be escaped'])
+```
+
+That lookup creation will fail because that new line char quote may create null fields. To avoid this, add `"escape_newline": true` to the lookup configuration file and `escape_newline=True` to the `Lookup` constructor. Below, an example for the constructor is shown:
+
+```python
+lookup = Lookup(name=self.lookup_name, historic_tag=None, con=con, escape_newline=True)
+```
+
+To see an example for the lookup configuration please refer to the one shown at the start of the document.
+
+This will escape ALL new line chars in the field value by adding a second backslash to it.
+
+The default behavior is to NOT escape any new line chars.

--- a/tests/integration/resources/testfile_lookup_with_quotes.csv
+++ b/tests/integration/resources/testfile_lookup_with_quotes.csv
@@ -2,4 +2,4 @@ KEY,DATA
 Key_one,Message_one
 Key_two,Message_two
 Key_three,Message_thre
-Key_four,Monitor 24" and 19
+Key_four,Monitor 24" \nand 19

--- a/tests/integration/test_sender_cli.py
+++ b/tests/integration/test_sender_cli.py
@@ -386,6 +386,7 @@ def test_cli_escape_quotes(setup):
             "-lk",
             "KEY",
             "-eq",
+            "-enl",
             "--no-verify-certificates",
         ],
     )

--- a/tests/unit/test_sender_number_lookup.py
+++ b/tests/unit/test_sender_number_lookup.py
@@ -23,6 +23,13 @@ def test_process_fields_does_not_modify_arguments():
     assert fields == ["a", "b", "c"]
     assert processed_fields == '"b","a","c"'
 
+def test_process_fields_does_modify_newline():
+    fields = ["a\ns", "b", "c"]
+    processed_fields = Lookup.process_fields(fields, key_index=1, escape_newline=True)
+
+    assert fields == ["a\ns", "b", "c"]
+    assert processed_fields == '"b","a\\ns","c"'
+
 
 # Clean field
 @pytest.mark.parametrize(


### PR DESCRIPTION
## [6.0.2] - 2025-03-07

### Added
 - Added new --escapenewline or -enl option in lookup creation, edition and deletion. It will escape with
double backslash any new line char found inside a csv field.