### PR TITLE
Feat/al 1340 warning lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.3] - 2025-03-07
+
+### Deprecated
+ - Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables.
+This method will soon be deprecated on the Devo backend.
+As an alternative, you can use the Lookups API: [Lookups API Documentation](https://docs.devo.com/space/latest/127500289/Lookups+API).
+The Python SDK will support the Lookups API in future versions.
+
 ## [6.0.2] - 2025-03-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.0.3] - 2025-03-07
+## [6.0.3] - 2025-03-19
 
 ### Deprecated
  - Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables.

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = "Devo Python Library."
 __url__ = "http://www.devo.com"
-__version__ = "6.0.2"
+__version__ = "6.0.3"
 __author__ = "Devo"
 __author_email__ = "support@devo.com"
 __license__ = "MIT"

--- a/devo/sender/lookup.py
+++ b/devo/sender/lookup.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
-"""File with utils for send Lookups to Devo"""
+"""File with utils for send Lookups to Devo
+
+This method, based on the `my.lookup.data` and `my.lookup.control` tables, will soon be deprecated on the Devo backend.
+As an alternative, you can use the Lookups API: [https://docs.devo.com/space/latest/127500289/Lookups+API].
+The Python SDK will support the Lookups API in future versions.
+"""
+
 
 import csv
 import re
 import sys
 import time
+import warnings
 
 from devo.sender.data import open_file
 
@@ -291,6 +298,15 @@ class Lookup:
         :param action: action, can be START or END
         :return:
         """
+        if event == self.EVENT_START:
+            warnings.warn(
+                "The lookup upload functionality based on the `my.lookup.data` and `my.lookup.control` tables "
+                "will be deprecated in the future. Instead, you can use the Lookups API: "
+                "https://docs.devo.com/space/latest/127500289/Lookups+API. The next version of the Python SDK will be "
+                "based on this API.",
+                DeprecationWarning,
+                stacklevel=2
+            )
         if event == self.EVENT_END:
             time.sleep(self.delay)
         line = "%s_%s|%s|%s" % (self.lookup_id, self.name, event, headers)

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -13,12 +13,11 @@
 
 <!-- /code_chunk_output -->
 
-::: warning
-:warning: **Warning:** Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables. 
-This method will soon be deprecated on the Devo backend.
-As an alternative, you can use the Lookups API: [Lookups API Documentation](https://docs.devo.com/space/latest/127500289/Lookups+API).
-The Python SDK will support the Lookups API in future versions.
-:::
+> [!WARNING]  
+>  Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables. 
+> This method will soon be deprecated on the Devo backend.
+> As an alternative, you can use the Lookups API: [Lookups API Documentation](https://docs.devo.com/space/latest/127500289/Lookups+API).
+> The Python SDK will support the Lookups API in future versions.
 
 
 ## Overview

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -13,6 +13,14 @@
 
 <!-- /code_chunk_output -->
 
+::: warning
+:warning: **Warning:** Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables. 
+This method will soon be deprecated on the Devo backend.
+As an alternative, you can use the Lookups API: [Lookups API Documentation](https://docs.devo.com/space/latest/127500289/Lookups+API).
+The Python SDK will support the Lookups API in future versions.
+:::
+
+
 ## Overview
 
 This library allows you to send lookups to the Devo platform.


### PR DESCRIPTION
## [6.0.3] - 2025-03-19

### Deprecated
 - Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables.
This method will soon be deprecated on the Devo backend.
As an alternative, you can use the Lookups API: [Lookups API Documentation](https://docs.devo.com/space/latest/127500289/Lookups+API).
The Python SDK will support the Lookups API in future versions.