### PR TITLE
feat: API Lookup developer guide in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.6] - 2025-05-26
+
+### Fix
+ - API Lookup developer guide  reference in legacy lookup documentation
+
 ## [6.0.5] - 2025-05-23
 
 ### Added

--- a/devo/__version__.py
+++ b/devo/__version__.py
@@ -1,6 +1,6 @@
 __description__ = "Devo Python Library."
 __url__ = "http://www.devo.com"
-__version__ = "6.0.5"
+__version__ = "6.0.6"
 __author__ = "Devo"
 __author_email__ = "support@devo.com"
 __license__ = "MIT"

--- a/docs/sender/lookup.md
+++ b/docs/sender/lookup.md
@@ -17,7 +17,7 @@
 > Right now the upload of lookups is based on the `my.lookup.data` and `my.lookup.control` tables. 
 > This method is deprecated on the Devo backend, and it will be discontinued on 1st January 2026.
 > As an alternative, you can use the Lookups API: [Lookups API Documentation](https://docs.devo.com/space/latest/127500289/Lookups+API).
-> There is a [developer guide](docs/sender/api_lookup_guide.md) in documentation.
+> There is a [developer guide](api_lookup_guide.md) in documentation.
 
 ## Overview
 


### PR DESCRIPTION
## [6.0.6] - 2025-05-26

### Fix
 - API Lookup developer guide  reference in legacy lookup documentation